### PR TITLE
Add run script extensions for a Django project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Commands
 - clean-cache: Empty cache files, which are saved between projects (eg, yarn)
 ```
 
+## run-django
+
+``` bash
+yo canonical-webteam:run-django
+```
+
+Install a version of the `run` script which will also use
+[docker-django](https://github.com/canonical-webteam/docker-django) to run a Django application on `./run start`.
+
 # License
 
 This codebase is licensed with [GNU Lesser General Public License version 3](LICENSE.md).

--- a/generators/index.js
+++ b/generators/index.js
@@ -4,6 +4,7 @@ const introduction = `
 Available scripts:
 
 - run: Installs the basic ./run script for running yarn with docker
+- run-django: Install the ./run script for a Django project
 
 To run one, type:
 

--- a/generators/run-django/index.js
+++ b/generators/run-django/index.js
@@ -1,0 +1,12 @@
+'use strict';
+const Generator = require('yeoman-generator');
+
+module.exports = class extends Generator {
+  initializing() {
+    this.composeWith(
+      require.resolve('../run'),
+      {django: true}
+    );
+  }
+};
+

--- a/generators/run/index.js
+++ b/generators/run/index.js
@@ -4,10 +4,19 @@ const Generator = require('yeoman-generator');
 
 module.exports = class extends Generator {
   writing() {
+    // Defaults
+    let options = {
+      'django': false
+    };
+
+    // Overrides
+    Object.assign(options, this.options);
+
     // Use shared templates
     this.fs.copyTpl(
       this.templatePath('run'),
-      this.destinationPath('run')
+      this.destinationPath('run'),
+      options
     );
   }
 };

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -8,33 +8,36 @@
 #
 # Update it to the latest version with:
 #
-# $ sudo npm install -g generator-canonical-webteam
-# $ yo canonical-webteam:run
+# $ sudo npm install -g yo generator-canonical-webteam
+# $ yo canonical-webteam:run<% if (django) { %>-django<% } %>
 
 set -euo pipefail
 
 # Define the versions of the two docker images
-yarn_image="canonicalwebteam/yarn:v0.2.0"
+<% if (django) { %>django_image="canonicalwebteam/django:v1.2.2"
+<% } %>yarn_image="canonicalwebteam/yarn:v0.2.0"
 
 USAGE="Usage
 ===
 
   $ ./run \\
     [-m|--node-module PATH]  # A path to a local node module to use instead of the installed dependencies \\
-    [COMMAND]                # Optionally provide a command to run
+<% if (django) { %>    [--no-debug]             # Turn off Django's DEBUG setting \\
+<% } %>    [COMMAND]                # Optionally provide a command to run
 
 If no COMMAND is provided, \`serve\` will be run.
 
 Commands
 ---
 
-- serve [-p|--port PORT] [-w|--watch] [-d|--detach]: Run \`yarn run serve\` (optionally running \`watch\` in the background)
+- serve [-p|--port PORT] [-w|--watch] [-d|--detach]: Run <% if (django) { %>Run the development server<% } else { %>\`yarn run serve\`<% } %> (optionally running \`watch\` in the background)
 - watch: Run \`yarn run watch\`
 - build: Run \`yarn run build\`
 - test: Run \`yarn run test\`
 - stop: Stop any running containers
 - yarn <args>: Run yarn
-- clean: Remove all images and containers, any installed dependencies and the .docker-project file
+<% if (django) { %>- django <args>: Run ./manage.py <args>
+<% } %>- clean: Remove all images and containers, any installed dependencies and the .docker-project file
 - clean-cache: Empty cache files, which are saved between projects (eg, yarn)
 "
 
@@ -73,11 +76,11 @@ fi
 # Settings
 module_volumes=()
 yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-yarn-cache}"
+<% if (django) { %>pip_dependencies_volume="${project}-pip-dependencies"<% } %>
 
 # Defaults environment settings
 PORT=8000
-
-# Import environment settings
+<% if (django) { %>DJANGO_DEBUG=true<% } %>
 if [ -f .env ]; then
     export $(cat .env | grep -v ^\# | xargs)
 fi
@@ -95,6 +98,9 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     key="$1"
 
     case $key in
+<% if (django) { %>
+        --no-debug) DJANGO_DEBUG=false ;;
+<% } %>
         -m|--node-module)
             if [ -z "${2:-}" ]; then invalid "Missing module name. Usage: --node-module <path-to-module>."; fi
             module_volumes+=("--volume" "${2}":"`pwd`/node_modules/$(basename ${2})")
@@ -159,6 +165,21 @@ yarn_install () {
         --volume ${yarn_cache_volume}:/home/shared/.cache/yarn/  `# Bind yarn cache to volume` \
         ${yarn_image} install  `# Install yarn dependencies`
 }
+<% if (django) { %>
+django_run () {
+    container_name="${1}"
+    command="${2:-}"
+    extra_options="${3:-}"
+
+    # Run Django using the docker image
+    run_as_user ${container_name} \
+        --volume ${pip_dependencies_volume}:/usr/local/lib/python2.7/site-packages  `# Store dependencies in a docker volume`  \
+        --env PORT=${PORT}                        `# Set the port correctly`  \
+        --env DJANGO_DEBUG=${DJANGO_DEBUG}        `# Set django debug mode`  \
+        ${extra_options}                          `# Any extra docker options`  \
+        ${django_image} ${command}                `# Run command in the Django image`
+}
+<% } %>
 
 # Find current run command
 run_command=${1:-}
@@ -196,11 +217,13 @@ case $run_command in
             yarn_run "${project}-watch" "run watch" "--detach"  # Run watch in the background
         fi
 
-        # Run the serve container, publishing the port, and detaching if required
-        yarn_run "${project}-serve" "run serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
+        # Detach the serve container to run it in the background
+        <% if (django) { %>django_run "${project}-serve" "" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
+        <% } else { %>yarn_run "${project}-serve" "run serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
+        <% } %>
     ;;
     "stop")
-        echo "Killing all running containers for ${project}"
+        echo "Stopping all running containers for ${project}"
         running_containers="$(docker ps --quiet --filter name=${project})"
         docker kill ${running_containers}
     ;;
@@ -216,12 +239,11 @@ case $run_command in
     "test")
         yarn_install
         yarn_run "${project}-yarn-test" "run test"
+        <% if (django) { %>django_run "${project}-django-test" "test"<% } %>
     ;;
     "clean")
-        if package_has_script serve; then
-            echo "Running 'clean' yarn script"
-            yarn_run "${project}-clean" "run clean"  # Run the clean script
-        fi
+        echo "Running 'clean' yarn script"
+        yarn_run "${project}-clean" "run clean" || true  # Run the clean script
 
         echo "Removing all containers, volumes and networks for project: ${project}"
         project_containers="$(docker ps --all --quiet --filter name=${project})"
@@ -241,6 +263,7 @@ case $run_command in
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
         docker volume rm --force ${yarn_cache_volume}
     ;;
-    "yarn") yarn_run "${project}-yarn-$(date +'%s')" "${@}" ;;
+<% if (django) { %>    "django") django_run "${project}-django-$(date +'%s')" "${@}" "--rm" ;;
+<% } %>    "yarn") yarn_run "${project}-yarn-$(date +'%s')" "${@}" ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac


### PR DESCRIPTION
This builds on #1, please merge that first.

A new generator script, which simply uses the existing `run` generator
script, but with "django=true".

The template for the `run` script now adds many new lines for running a
Django project. The main changes are tht there is now a `./run django`
command, and that `./run start` now runs Django instead of `yarn run
start`.

QA
--

Make sure #1 is merged first.

Prepare:

``` bash
sudo npm install -g yo  # You need Yeoman
sudo npm link  # Link this branch
cd ..
git clone https://github.com/canonical-websites/www.ubuntu.com  # Get ubuntu.com project
cd www.ubuntu.com
```

Add generate run script for www.ubuntu.com to overwrite existing one:

``` bash
yo canonical-webteam:run-django --force
```

Now try out all the script functions:

``` bash
./run --help
./run
./run start --watch --detach
./run django shell
./run stop
./run clean
./run <other things>
```