### PR TITLE
Correct usage of unset `serve_detached`

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -252,7 +252,7 @@ case $run_command in
 
         # Run watch command in the background
         if ${run_watcher}; then
-            if ! ${serve_detached}; then trap "kill_container ${project}-watch" EXIT; fi
+            if [ -z "${detach}" ];  then trap "kill_container ${project}-watch" EXIT; fi
             yarn_run "${project}-watch" "run watch" "--detach"  # Run watch in the background
         fi
 


### PR DESCRIPTION
While using the generated django run script, it complained of an unset `serve_detached` variable. I have changed it to use the `detach` variable in line with other options.


# QA
After running `yo canonical-webteam:run-django`
`./run` and `./run serve --detach` should work correctly
