### PR TITLE
Give args to serve and no need to quote them

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -338,7 +338,7 @@ case $run_command in
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
         docker volume rm --force ${node_cache_volume}
     ;;
-<% if (django) { %>    "django") django_run "${project}-django-$(date +'%s')" "'${*}'" "--rm" ;;
-<% } %>    "node") node_run "${project}-node-$(date +'%s')" "'${*}'" ;;
+<% if (django) { %>    "django") django_run "${project}-django-$(date +'%s')" "${*}" "--rm" ;;
+<% } %>    "node") node_run "${project}-node-$(date +'%s')" "${*}" ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -338,7 +338,7 @@ case $run_command in
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
         docker volume rm --force ${node_cache_volume}
     ;;
-<% if (django) { %>    "django") django_run "${project}-django-$(date +'%s')" "${@}" "--rm" ;;
-<% } %>    "node") node_run "${project}-node-$(date +'%s')" "${@}" ;;
+<% if (django) { %>    "django") django_run "${project}-django-$(date +'%s')" "'${*}'" "--rm" ;;
+<% } %>    "node") node_run "${project}-node-$(date +'%s')" "'${*}'" ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -274,9 +274,9 @@ case $run_command in
         <% } %>
 
         # Run the serve container, publishing the port, and detaching if required
-        <% if (django) { %>django_run "${project}-serve" "" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}<% if (db) { %> --network ${network_name}<% } %>"
-        <% } else if (jekyll) { %>bundler_run "${project}-serve" "jekyll serve -P ${PORT} -H 0.0.0.0" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
-        <% } else { %>node_run "${project}-serve" "yarn run serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
+        <% if (django) { %>django_run "${project}-serve" "" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}<% if (db) { %> --network ${network_name}<% } %> ${*}"
+        <% } else if (jekyll) { %>bundler_run "${project}-serve" "jekyll serve -P ${PORT} -H 0.0.0.0" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${*}"
+        <% } else { %>node_run "${project}-serve" "yarn run serve ${*}" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach}"
         <% } %>
     ;;
     "stop")


### PR DESCRIPTION
Adding the ability to pass arguments to serve, primarily for Tutorials so that it can serve a single file for testing and development. Such as `./run serve new-tutorial.md`.

This also required me to fix the need to quote arguments, so I did that too!


## QA

Checkout this PR for Tutorials: https://github.com/canonical-websites/tutorials.ubuntu.com/pull/208
Use this new ./run
Try `./run node yarn run serve examples` - No error!
Try `./run serve testing` - An error about the `testing` file or folder not existing!