### PR TITLE
sass-lint should only specify rules

### DIFF
--- a/generators/run/templates/sass-lint.yml
+++ b/generators/run/templates/sass-lint.yml
@@ -1,13 +1,6 @@
 # Default config: https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml
 # Example config: https://github.com/sasstools/sass-lint/blob/master/docs/sass-lint.yml
 
-files:
-  include: 'scss/**/*.s+(a|c)ss'
-  ignore:
-    - 'scss/_base_reset.scss'
-    - 'scss/grid/**/*'
-    - 'scss/_layout_grid.scss'
-    - 'scss/deprecate/**/*'
 rules:
   # Documentation: https://github.com/sasstools/sass-lint/tree/master/docs/rules
 


### PR DESCRIPTION
The files to be tested to should passed to `sass-lint` directly, and so there should be no need to include or ignore files in the `.sass-lint.yaml`.