### PR TITLE
Add version option

### DIFF
--- a/generators/run/index.js
+++ b/generators/run/index.js
@@ -3,6 +3,7 @@
 // Core packages
 const fs = require('fs');
 const util = require('util');
+const pjson = require('../../package.json');
 
 // Third-party packages
 const Generator = require('yeoman-generator');
@@ -50,8 +51,11 @@ module.exports = class extends Generator {
     let options = {
       'django': false,
       'db': false,
-      'jekyll': false
+      'jekyll': false,
+      'version': pjson.version
     };
+
+
 
     // Overrides
     Object.assign(options, this.options);

--- a/generators/run/index.js
+++ b/generators/run/index.js
@@ -55,8 +55,6 @@ module.exports = class extends Generator {
       'version': pjson.version
     };
 
-
-
     // Overrides
     Object.assign(options, this.options);
 

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -18,6 +18,8 @@ set -euo pipefail
 <% } else if (jekyll) { %>bundler_image="canonicalwebteam/bundler:v0.1.2"
 <% } %>node_image="canonicalwebteam/node:v0.1.0"
 
+VERSION="<%= version %>"
+
 USAGE="Usage
 ===
 
@@ -116,6 +118,7 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             shift
         ;;
         -h|--help) echo "$USAGE"; exit ;;
+        -v|--version) echo "Generated from generator-canonical-webteam@$VERSION"; exit ;;
         *) invalid "Option '${key}' not recognised." ;;
     esac
     shift
@@ -342,7 +345,7 @@ case $run_command in
         echo "Removing cache volume ${pip_cache_volume}"
         containers_using_volume=$(docker ps --quiet --all --filter "volume=${pip_cache_volume}")
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-        docker volume rm --force ${pip_cache_volume}
+        <% if (django) { %> docker volume rm --force ${pip_cache_volume} <% } %>
     ;;
 <% if (django) { %>    "django")
         expose_port=""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
## Done
Add -v|--version options to output the version of the script

## QA
Run `./run -v` and see it outputs the version

## Details
Fixes https://github.com/canonical-webteam/generator-canonical-webteam/issues/27