### PR TITLE
Only clear pip cache in django scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/generators/run/templates/gitignore
+++ b/generators/run/templates/gitignore
@@ -25,6 +25,7 @@ pids
 
 # [deps] Local dependencies
 .bundle/
+.package-lock.json  # Normally lockfiles would be committed, but we use yarn instead of NPM for locking dependencies
 node_modules/
 bower_components/
 vendor/

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -341,11 +341,13 @@ case $run_command in
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
         docker volume rm --force ${yarn_cache_volume}
 
-        # Clean node cache volume
+        <% if (django) { %>
+        # Clean pip cache volume
         echo "Removing cache volume ${pip_cache_volume}"
         containers_using_volume=$(docker ps --quiet --all --filter "volume=${pip_cache_volume}")
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-        <% if (django) { %> docker volume rm --force ${pip_cache_volume} <% } %>
+        docker volume rm --force ${pip_cache_volume}
+        <% } %>
     ;;
 <% if (django) { %>    "django")
         expose_port=""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
`pip_cache_volume` is only used in django projects, so we need to make sure `clean-cache` only tried to delete the pip cache in those projects, otherwise we get an error about thew variable nont being declared.

I also did a driveby for ignoring `package-lock.json` and bumping the version to v0.3.2.