### PR TITLE
Optional serve args

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -269,9 +269,9 @@ case $run_command in
         fi
 
         # Run the serve container, publishing the port, and detaching if required
-        <% if (django) { %>django_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}"
-        <% } else if (jekyll) { %>bundler_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" jekyll serve -P ${PORT} -H 0.0.0.0
-        <% } else { %>node_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" yarn run serve
+        <% if (django) { %>django_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" $*
+        <% } else if (jekyll) { %>bundler_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" jekyll serve -P ${PORT} -H 0.0.0.0 $*
+        <% } else { %>node_run "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" yarn run serve $*
         <% } %>
     ;;
     "stop")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Add back ability to pass arguments to the `./run serve` command.

Tested functionality with Docker's `bash:3.2`, which should match Mac's current Bash version.

## QA

- `npm link` this repo
- Go to https://github.com/canonical-websites/tutorials.ubuntu.com repo
- Update run script (only) with `yo canonical-webteam:run`
- Try `./run serve` and you should see one example tutorial
- Try `./run serve ./tutorials/*/` and you should see a lot of tutorials!