### PR TITLE
Flask support; other changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v0.2.3 (2017-05-20): Use latest Django image
 v0.2.3 (2017-05-20): Defaults: Clean up more files
 v0.3.0 (2017-05-21): Intelligently update blocks in gitignore
 v1.0.0 (2017-08-20): Unify run script for all project types
+v1.1.0 (2017-08-31): Manage requirements.txt directly; Add flask support

--- a/generators/run/templates/gitignore
+++ b/generators/run/templates/gitignore
@@ -28,10 +28,11 @@ pids
 
 # [deps] Local dependencies
 .bundle/
-.package-lock.json  # Normally lockfiles would be committed, but we use yarn instead of NPM for locking dependencies
 node_modules/
 bower_components/
 vendor/
+# Normally lockfiles would be committed, but we use yarn instead of NPM for locking dependencies
+package-lock.json  
 
 # [build] Built files
 /build/

--- a/generators/run/templates/gitignore
+++ b/generators/run/templates/gitignore
@@ -40,6 +40,7 @@ _site/
 
 # [env] Local environment settings
 .docker-project
+.requirements.*.hash
 .envrc
 env/
 env[23]/

--- a/generators/run/templates/package.json
+++ b/generators/run/templates/package.json
@@ -1,14 +1,11 @@
 {
-  "//": "Created by generator-canonical-webteam@<%= version %>",
   "scripts": {
-    "//": "Scripts updated by generator-canonical-webteam@<%= version %>",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "build": "node-sass --include-path node_modules static/sass --output static/css",
     "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata"
   },
   "devDependencies": {
-    "//": "Dependencies updated by generator-canonical-webteam@<%= version %>",
     "node-sass": "^4.5.3",
     "sass-lint": "^1.10.2"
   }

--- a/generators/run/templates/package.json
+++ b/generators/run/templates/package.json
@@ -1,9 +1,5 @@
 {
   "//": "Created by generator-canonical-webteam@<%= version %>",
-  "name": "ubuntu-website",
-  "version": "0.0.1",
-  "description": "Django website for ubuntu.com",
-  "main": "index.js",
   "scripts": {
     "//": "Scripts updated by generator-canonical-webteam@<%= version %>",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
@@ -11,12 +7,6 @@
     "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata"
   },
-  "keywords": [
-    "website",
-    "ubuntu"
-  ],
-  "author": "Canonical webteam",
-  "license": "LGPL v3",
   "devDependencies": {
     "//": "Dependencies updated by generator-canonical-webteam@<%= version %>",
     "node-sass": "^4.5.3",

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -46,7 +46,7 @@ Commands
 # Define docker images versions
 python_image="canonicalwebteam/python3:v1.1.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
-node_image="canonicalwebteam/node:v0.1.1"
+node_image="canonicalwebteam/node:v0.2.0"
 
 # Global volume names
 yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-node-cache}"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -46,7 +46,7 @@ Commands
 # Define docker images versions
 python_image="canonicalwebteam/python3:v1.1.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
-node_image="canonicalwebteam/node:v0.2.0"
+node_image="canonicalwebteam/node:v0.2.1"
 
 # Global volume names
 yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-node-cache}"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -346,6 +346,7 @@ case $run_command in
 
         kill_container "${project}-node-test"
         kill_container "${project}-django-test"
+        kill_container "${project}-python-test"
         kill_container "${project}-flake8-test"
 
         # Run node tests
@@ -362,7 +363,18 @@ case $run_command in
             echo "Running Django tests"
             echo "==="
             python_run "${project}-django-test" "" python3 manage.py test || test_error=true
+        fi
 
+        # Generic python tests
+        if [ -f tests.py ]; then
+            echo "==="
+            echo "Running python tests from tests.py"
+            echo "==="
+            python_run "${project}-python-test" "" python3 tests.py || test_error=true
+        fi
+
+        # Run flake8 (python syntax) checks
+        if [ -f manage.py ] || [ -f webapp.py ] || [ -f tests.py ]; then
             echo "==="
             echo "Running flake8 tests"
             echo "==="
@@ -374,14 +386,7 @@ case $run_command in
                 ${python_image} flake8 --exclude '*env*,node_modules' || test_error=true
         fi
 
-        # Generic python tests
-        if [ -f tests.py ]; then
-            echo "==="
-            echo "Running python tests from tests.py"
-            echo "==="
-            python_run "${project}-python-tests" "" python3 tests.py || test_error=true
-        fi
-
+        # Report success or failure
         if ${test_error}; then
             echo "==="
             echo "Tests failed"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -306,7 +306,7 @@ case $run_command in
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
         elif [ -f webapp.py ]; then  # flask
             run_function="python_run"
-            run_command="flask run --host 0.0.0.0:${PORT}"
+            run_command="flask run --host 0.0.0.0 --port ${PORT}"
             run_options="--env FLASK_APP=webapp.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -463,6 +463,9 @@ case $run_command in
         fi
     ;;
     "clean")
+        echo "Remove requirements hash file"
+        rm -rf .requirements.${project}.hash
+
         echo "Running 'clean' yarn script"
         node_run "${project}-clean" "" yarn run clean || true  # Run the clean script
 

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -229,6 +229,16 @@ python_run () {
 
         # Wait for database to connect
         docker run ${tty} --rm --network "${network_name}" ${python_image} /wait-for-postgres db
+
+        # Provision database for django sites
+        if [ -f manage.py ]; then
+            run_as_user ${container_name} \
+                --volume ${python_lib_volume}:/usr/local/lib/          `# Store dependencies in a docker volume`  \
+                --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
+                --network "${network_name}"                            `# Use an isolated network`  \
+                ${python_image} python3 manage.py migrate              `# Run command in the Python image`
+        fi
+
     fi
 
     # Choose debug variable

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -238,7 +238,7 @@ python_run () {
 
     # Update dependencies if required
     if [ -f requirements.txt ]; then
-        if type md5sum 2> /dev/null; then
+        if type md5sum &> /dev/null; then
             requirements_hash=$(md5sum requirements.txt | awk '{print $1;}')
         else
             requirements_hash=$(md5 requirements.txt | awk '{print $4;}')

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -266,8 +266,6 @@ if [[ -n "${run_command}" ]]; then shift; fi
 # Do the real business
 case $run_command in
     ""|"serve")
-        node_install
-
         # Read optional arguments
         detach=""
         run_watcher=false
@@ -287,7 +285,11 @@ case $run_command in
             shift
         done
 
-        node_run "${project}-build" "" yarn run build
+        # Setup yarn dependencies
+        if [ -f package.json ]; then
+            node_install
+            node_run "${project}-build" "" yarn run build
+        fi
 
         # Run watch command in the background
         if ${run_watcher}; then

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -245,7 +245,7 @@ python_run () {
     debug="DEBUG=${RUN_DEBUG}"
     if [ -f manage.py ]; then
         debug="DJANGO_DEBUG=${RUN_DEBUG}"
-    elif [ -f webapp.py ]; then
+    elif [ -f app.py ]; then
         debug="FLASK_DEBUG=${RUN_DEBUG}"
     fi
 
@@ -304,10 +304,10 @@ case $run_command in
         if [ -f manage.py ]; then  # django
             run_function="python_run"
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
-        elif [ -f webapp.py ]; then  # flask
+        elif [ -f app.py ]; then  # flask
             run_function="python_run"
             run_command="flask run --host 0.0.0.0 --port ${PORT}"
-            run_options="--env FLASK_APP=webapp.py"
+            run_options="--env FLASK_APP=app.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
@@ -391,7 +391,7 @@ case $run_command in
         fi
 
         # Run flake8 (python syntax) checks
-        if [ -f manage.py ] || [ -f webapp.py ] || [ -f tests.py ]; then
+        if [ -f manage.py ] || [ -f app.py ] || [ -f tests.py ]; then
             echo "==="
             echo "Running flake8 tests"
             echo "==="

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -44,7 +44,7 @@ Commands
 ##
 
 # Define docker images versions
-python_image="canonicalwebteam/python:v1.0.0"
+python_image="canonicalwebteam/python3:v1.0.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
 node_image="canonicalwebteam/node:v0.1.0"
 
@@ -228,7 +228,7 @@ python_run () {
         fi
 
         # Wait for database to connect
-        docker run --rm --network "${network_name}" ${python_image} /wait-for-postgres db
+        docker run ${tty} --rm --network "${network_name}" ${python_image} /wait-for-postgres db
     fi
 
     # Choose debug variable

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -298,19 +298,21 @@ case $run_command in
         # Select run function and run command
         run_function="node_run"
         run_command="yarn run serve"
+        run_options=""
         if [ -f manage.py ]; then  # django
             run_function="python_run"
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
         elif [ -f webapp.py ]; then  # flask
             run_function="python_run"
             run_command="flask run 0.0.0.0:${PORT}"
+            run_options="--env FLASK_APP=webapp.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
         fi
 
         # Run the serve container, publishing the port, and detaching if required
-        ${run_function} "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts}" ${run_command} $*
+        ${run_function} "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -46,7 +46,7 @@ Commands
 # Define docker images versions
 python_image="canonicalwebteam/python3:v1.1.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
-node_image="canonicalwebteam/node:v0.1.0"
+node_image="canonicalwebteam/node:v0.1.1"
 
 # Global volume names
 yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-node-cache}"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -279,6 +279,8 @@ python_run () {
     debug="DEBUG=${RUN_DEBUG}"
     if [ -f manage.py ]; then
         debug="DJANGO_DEBUG=${RUN_DEBUG}"
+    elif [ -f app.py ]; then
+        debug="FLASK_DEBUG=${RUN_DEBUG}"
     fi
 
     # Run the command in the python docker image
@@ -337,6 +339,10 @@ case $run_command in
         if [ -f manage.py ]; then  # django
             run_function="python_run"
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
+        elif [ -f app.py ]; then  # flask
+            run_function="python_run"
+            run_command="flask run --host 0.0.0.0 --port ${PORT}"
+            run_options="--env FLASK_APP=app.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
@@ -420,7 +426,7 @@ case $run_command in
         fi
 
         # Run flake8 (python syntax) checks
-        if [ -f manage.py ] || [ -f tests.py ]; then
+        if [ -f manage.py ] || [ -f app.py ] || [ -f tests.py ]; then
             echo "==="
             echo "Running flake8 tests"
             echo "==="

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -232,13 +232,13 @@ python_run () {
             requirements_hash=$(md5 requirements.txt | awk '{print $4;}')
         fi
 
-        if [ ! -f ".requirements.hash" ] || [ "$(cat .requirements.hash)" != "${requirements_hash}" ]; then
+        if [ ! -f ".requirements.${project}.hash" ] || [ "$(cat .requirements.${project}.hash)" != "${requirements_hash}" ]; then
             echo "Updating dependencies from requirements.txt:" >> /dev/stderr
             docker_run "${pip_container}" \
                 --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
                 --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
                 ${python_image} pip3 install --requirement requirements.txt  # Install new dependencies
-            echo -n "${requirements_hash}" > .requirements.hash
+            echo -n "${requirements_hash}" > .requirements.${project}.hash
         fi
     fi
 

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -238,7 +238,7 @@ python_run () {
 
     # Update dependencies if required
     if [ -f requirements.txt ]; then
-        if type md5sum > /dev/null; then
+        if type md5sum 2> /dev/null; then
             requirements_hash=$(md5sum requirements.txt | awk '{print $1;}')
         else
             requirements_hash=$(md5 requirements.txt | awk '{print $4;}')

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -98,7 +98,7 @@ else
 fi
 
 # Set project specific container names
-python_lib_volume="${project}-python-lib"
+python_local_volume="${project}-python-local"
 db_container="${project}-db"
 db_volume="${project}-db"
 network_name="${project}-net"
@@ -233,7 +233,7 @@ python_run () {
         # Provision database for django sites
         if [ -f manage.py ]; then
             run_as_user ${container_name} \
-                --volume ${python_lib_volume}:/usr/local/lib/          `# Store dependencies in a docker volume`  \
+                --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
                 --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
                 --network "${network_name}"                            `# Use an isolated network`  \
                 ${python_image} python3 manage.py migrate              `# Run command in the Python image`
@@ -251,7 +251,7 @@ python_run () {
 
     # Run the command in the python docker image
     run_as_user ${container_name} \
-        --volume ${python_lib_volume}:/usr/local/lib/          `# Store dependencies in a docker volume`  \
+        --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
         --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
         --env PORT=${PORT}                                     `# Set the port correctly`  \
         --env ${debug}                                         `# Set debug mode`  \

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -44,7 +44,7 @@ Commands
 ##
 
 # Define docker images versions
-python_image="canonicalwebteam/python3:v1.0.1"
+python_image="canonicalwebteam/python3:v1.1.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
 node_image="canonicalwebteam/node:v0.1.0"
 
@@ -100,6 +100,7 @@ fi
 # Set project specific container names
 python_local_volume="${project}-python-local"
 db_container="${project}-db"
+pip_container="${project}-db"
 db_volume="${project}-db"
 network_name="${project}-net"
 
@@ -144,9 +145,7 @@ kill_container () {
     fi
 }
 
-run_as_user () {
-    # Run a container as the current user and in the current directory context
-
+docker_run () {
     # Get options
     container_name=${1}; shift  # Get container_name as first argument
 
@@ -157,7 +156,6 @@ run_as_user () {
     docker run  \
         --name ${container_name}  `# Name the container` \
         --rm                      `# Remove the container once it's finished`  \
-        --user $(id -u):$(id -g)  `# Use the current user inside container`  \
         ${env_file}               `# Pass environment variables into the container, if file exists`  \
         --volume `pwd`:`pwd`      `# Mirror current directory inside container`  \
         --workdir `pwd`           `# Set current directory to the image's work directory`  \
@@ -172,7 +170,13 @@ bundler_run () {
     # Kill existing containers
     kill_container "${container_name}"
 
-    run_as_user "${container_name}" \
+    # Create etc volume with the new user
+    docker run --rm --volume ${project}-bundler-etc:/etc ${bundler_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+
+    # Run a command in the "bundler" image
+    docker_run "${container_name}" \
+        --user $(id -u):$(id -g)             `# Use the current user`  \
+        --volume ${project}-bundler-etc:/etc `# Use etc with corresponding user added`  \
         --volume ${project}-bundle:/bundler  `# Persist ruby dependencies in a docker volume`  \
         ${extra_options}                     `# Extra options`  \
         ${bundler_image} $@                  `# Run the jeklyll command`
@@ -183,8 +187,13 @@ node_run () {
     container_name="${1}"; shift
     extra_options="${1:-}"; shift
 
+    # Create etc volume with the new user
+    docker run --rm --volume ${project}-node-etc:/etc ${node_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+
     # Run a command in the "node" image
-    run_as_user "${container_name}"  \
+    docker_run "${container_name}" \
+        --user $(id -u):$(id -g)                                 `# Use the current user`  \
+        --volume ${project}-node-etc:/etc                        `# Use etc with corresponding user added`  \
         --volume ${yarn_cache_volume}:/home/shared/.cache/yarn/  `# Bind cache to volume` \
         ${module_volumes[@]+"${module_volumes[@]}"}              `# Add any override modules as volumes`  \
         ${extra_options}                                         `# Extra options`  \
@@ -197,17 +206,43 @@ node_install () {
         node_run "${project}-bower-install" "" bower install
     fi
 
-    # Install yarn dependencies, without module overrides
-    run_as_user "${project}-yarn-install" \
+    # Create etc volume with the new user
+    docker run --rm --volume ${project}-node-etc:/etc ${node_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+
+    # Run a command in the "node" image
+    docker_run "${project}-yarn-install"  \
+        --user $(id -u):$(id -g)                                 `# Use the current user`  \
+        --volume ${project}-node-etc:/etc                        `# Use etc with corresponding user added`  \
         --volume ${yarn_cache_volume}:/home/shared/.cache/yarn/  `# Bind yarn cache to volume` \
-        ${node_image} yarn install  `# Install yarn dependencies`
+        ${node_image} yarn install                               `# Install yarn dependencies`
 }
 
 python_run () {
     container_name="${1}"; shift
     extra_options="${1:-}"; shift
 
-    if grep -q django.db.backends.postgresql_psycopg2 */settings.py; then
+    # Create etc volume with the new user
+    docker run --rm --volume ${project}-python-etc:/etc ${python_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+
+    # Update dependencies if required
+    if [ -f requirements.txt ]; then
+        if type md5sum > /dev/null; then
+            requirements_hash=$(md5sum requirements.txt | awk '{print $1;}')
+        else
+            requirements_hash=$(md5 requirements.txt | awk '{print $4;}')
+        fi
+
+        if [ ! -f ".requirements.hash" ] || [ "$(cat .requirements.hash)" != "${requirements_hash}" ]; then
+            echo "Updating dependencies from requirements.txt:" >> /dev/stderr
+            docker_run "${pip_container}" \
+                --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
+                --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
+                ${python_image} pip3 install --requirement requirements.txt  # Install new dependencies
+            echo -n "${requirements_hash}" > .requirements.hash
+        fi
+    fi
+
+    if grep -q django.db.backends.postgresql_psycopg2 */settings.py 2> /dev/null; then
         # Create isolated network
         if ! docker network inspect ${network_name} &> /dev/null; then
             docker network create ${network_name}
@@ -227,14 +262,13 @@ python_run () {
                 postgres                     `# Use the image for node version 7`
         fi
 
-        # Wait for database to connect
-        docker run ${tty} --rm --network "${network_name}" ${python_image} /wait-for-postgres db
-
         # Provision database for django sites
         if [ -f manage.py ]; then
-            run_as_user ${container_name} \
+            # Run a command in the "node" image
+            docker_run "${container_name}" \
+                --user $(id -u):$(id -g)                               `# Use the current user`  \
+                --volume ${project}-python-etc:/etc                    `# Use etc with corresponding user added`  \
                 --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
-                --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
                 --network "${network_name}"                            `# Use an isolated network`  \
                 ${python_image} python3 manage.py migrate              `# Run command in the Python image`
         fi
@@ -245,14 +279,13 @@ python_run () {
     debug="DEBUG=${RUN_DEBUG}"
     if [ -f manage.py ]; then
         debug="DJANGO_DEBUG=${RUN_DEBUG}"
-    elif [ -f app.py ]; then
-        debug="FLASK_DEBUG=${RUN_DEBUG}"
     fi
 
     # Run the command in the python docker image
-    run_as_user ${container_name} \
+    docker_run ${container_name} \
+        --user $(id -u):$(id -g)                               `# Use the current user`  \
+        --volume ${project}-python-etc:/etc                    `# Use etc with corresponding user added`  \
         --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
-        --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
         --env PORT=${PORT}                                     `# Set the port correctly`  \
         --env ${debug}                                         `# Set debug mode`  \
         ${extra_options}                                       `# Any extra docker options`  \
@@ -304,10 +337,6 @@ case $run_command in
         if [ -f manage.py ]; then  # django
             run_function="python_run"
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
-        elif [ -f app.py ]; then  # flask
-            run_function="python_run"
-            run_command="flask run --host 0.0.0.0 --port ${PORT}"
-            run_options="--env FLASK_APP=app.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
@@ -391,7 +420,7 @@ case $run_command in
         fi
 
         # Run flake8 (python syntax) checks
-        if [ -f manage.py ] || [ -f app.py ] || [ -f tests.py ]; then
+        if [ -f manage.py ] || [ -f tests.py ]; then
             echo "==="
             echo "Running flake8 tests"
             echo "==="
@@ -419,12 +448,24 @@ case $run_command in
         echo "Running 'clean' yarn script"
         node_run "${project}-clean" "" yarn run clean || true  # Run the clean script
 
-        echo "Removing all containers, volumes and networks for project: ${project}"
-        project_containers="$(docker ps --all --quiet --filter name=${project})"
+        echo "Removing docker objects for project: ${project}"
+
+        echo "- Removing containers using project volumes"
         project_volumes="$(docker volume ls --quiet --filter name=${project})"
-        project_networks="$(docker network ls --quiet --filter name=${project})"
-        if [ -n "${project_containers}" ]; then docker rm --force ${project_containers}; fi
+        for volume in ${project_volumes}; do
+            echo "  > Removing containers using volume ${volume}"
+            containers_using_volume="$(docker ps --all --quiet --filter volume=${volume})"
+            if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
+        done
+        echo "- Removing project volumes"
         if [ -n "${project_volumes}" ]; then docker volume rm --force ${project_volumes}; fi
+
+        echo "- Removing remaining project containers"
+        project_containers="$(docker ps --all --quiet --filter name=${project})"
+        if [ -n "${project_containers}" ]; then docker rm --force ${project_containers}; fi
+
+        echo "- Removing project networks"
+        project_networks="$(docker network ls --quiet --filter name=${project})"
         if [ -n "${project_networks}" ]; then docker network rm ${project_networks}; fi
 
         echo "Removing .docker-project file"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -306,7 +306,7 @@ case $run_command in
             run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
         elif [ -f webapp.py ]; then  # flask
             run_function="python_run"
-            run_command="flask run 0.0.0.0:${PORT}"
+            run_command="flask run --host 0.0.0.0:${PORT}"
             run_options="--env FLASK_APP=webapp.py"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -207,7 +207,7 @@ python_run () {
     container_name="${1}"; shift
     extra_options="${1:-}"; shift
 
-    if grep -q DATABASES */settings.py; then
+    if grep -q django.db.backends.postgresql_psycopg2 */settings.py; then
         # Create isolated network
         if ! docker network inspect ${network_name} &> /dev/null; then
             docker network create ${network_name}
@@ -226,6 +226,9 @@ python_run () {
                 --detach                     `# Run in the background` \
                 postgres                     `# Use the image for node version 7`
         fi
+
+        # Wait for database to connect
+        docker run --rm --network "${network_name}" ${python_image} /wait-for-postgres db
     fi
 
     # Choose debug variable

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -44,7 +44,7 @@ Commands
 ##
 
 # Define docker images versions
-python_image="canonicalwebteam/python3:v1.0.0"
+python_image="canonicalwebteam/python3:v1.0.1"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
 node_image="canonicalwebteam/node:v0.1.0"
 

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -135,6 +135,18 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     shift
 done
 
+create_current_user () {
+    image="${1}"
+    etc_volume="${2}"
+    uid=$(id -u)
+    gid=$(id -g)
+
+    if ! docker volume inspect ${etc_volume} &> /dev/null; then
+        docker run --rm --volume ${etc_volume}:/etc ${image} bash -c "grep -P '${gid}:$' /etc/group &> /dev/null || groupadd -g ${gid} app-user"
+        docker run --rm --volume ${etc_volume}:/etc ${image} bash -c "grep -P 'x:${uid}:' /etc/passwd &> /dev/null || useradd -u ${uid} -g ${gid} app-user"
+    fi
+}
+
 kill_container () {
     container_name="${1}"
 
@@ -171,7 +183,7 @@ bundler_run () {
     kill_container "${container_name}"
 
     # Create etc volume with the new user
-    docker run --rm --volume ${project}-bundler-etc:/etc ${bundler_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+    create_current_user "${bundler_image}" "${project}-bundler-etc"
 
     # Run a command in the "bundler" image
     docker_run "${container_name}" \
@@ -188,7 +200,7 @@ node_run () {
     extra_options="${1:-}"; shift
 
     # Create etc volume with the new user
-    docker run --rm --volume ${project}-node-etc:/etc ${node_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+    create_current_user "${node_image}" "${project}-node-etc"
 
     # Run a command in the "node" image
     docker_run "${container_name}" \
@@ -207,7 +219,7 @@ node_install () {
     fi
 
     # Create etc volume with the new user
-    docker run --rm --volume ${project}-node-etc:/etc ${node_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+    create_current_user "${node_image}" "${project}-node-etc"
 
     # Run a command in the "node" image
     docker_run "${project}-yarn-install"  \
@@ -222,7 +234,7 @@ python_run () {
     extra_options="${1:-}"; shift
 
     # Create etc volume with the new user
-    docker run --rm --volume ${project}-python-etc:/etc ${python_image} bash -c "getent passwd $(id -u) > /dev/null || (groupadd -g $(id -g) app-user && useradd -u $(id -u) -g $(id -g) app-user)"
+    create_current_user "${python_image}" "${project}-python-etc"
 
     # Update dependencies if required
     if [ -f requirements.txt ]; then

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -33,7 +33,7 @@ Commands
 - test: Run \`yarn run test\`
 - stop: Stop any running containers
 - node [-p|--expose-port PORT] <args>: Run a command in the node container (optionally exposing a port to the host)
-- django [-p|--expose-port PORT] <args>: Run a command in a django container (optionally exposing a port to the host)
+- python [-p|--expose-port PORT] <args>: Run a command in a python container (optionally exposing a port to the host)
 - bundler [-p|--expose-port PORT] <args>: Run a command in a bundler container (optionally exposing a port to the host)
 - clean: Remove all images and containers, any installed dependencies and the .docker-project file
 - clean-cache: Empty cache files, which are saved between projects (eg, yarn)
@@ -44,7 +44,7 @@ Commands
 ##
 
 # Define docker images versions
-django_image="canonicalwebteam/django:v2.2.1"
+python_image="canonicalwebteam/python:v1.0.0"
 bundler_image="canonicalwebteam/bundler:v0.1.2"
 node_image="canonicalwebteam/node:v0.1.0"
 
@@ -98,7 +98,7 @@ else
 fi
 
 # Set project specific container names
-django_lib_volume="${project}-django-lib"
+python_lib_volume="${project}-python-lib"
 db_container="${project}-db"
 db_volume="${project}-db"
 network_name="${project}-net"
@@ -203,7 +203,7 @@ node_install () {
         ${node_image} yarn install  `# Install yarn dependencies`
 }
 
-django_run () {
+python_run () {
     container_name="${1}"; shift
     extra_options="${1:-}"; shift
 
@@ -230,16 +230,20 @@ django_run () {
 
     # Choose debug variable
     debug="DEBUG=${RUN_DEBUG}"
-    if [ -f manage.py ]; then debug="DJANGO_DEBUG=${RUN_DEBUG}"; fi
+    if [ -f manage.py ]; then
+        debug="DJANGO_DEBUG=${RUN_DEBUG}"
+    elif [ -f webapp.py ]; then
+        debug="FLASK_DEBUG=${RUN_DEBUG}"
+    fi
 
-    # Run Django using the docker image
+    # Run the command in the python docker image
     run_as_user ${container_name} \
-        --volume ${django_lib_volume}:/usr/local/lib/          `# Store dependencies in a docker volume`  \
+        --volume ${python_lib_volume}:/usr/local/lib/          `# Store dependencies in a docker volume`  \
         --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
         --env PORT=${PORT}                                     `# Set the port correctly`  \
         --env ${debug}                                         `# Set debug mode`  \
         ${extra_options}                                       `# Any extra docker options`  \
-        ${django_image} $@                                     `# Run command in the Django image`
+        ${python_image} $@                                     `# Run command in the Python image`
 }
 
 # Find current run command
@@ -282,8 +286,11 @@ case $run_command in
         run_function="node_run"
         run_command="yarn run serve"
         if [ -f manage.py ]; then  # django
-            run_function="django_run"
-            run_command=""
+            run_function="python_run"
+            run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
+        elif [ -f webapp.py ]; then  # flask
+            run_function="python_run"
+            run_command="flask run 0.0.0.0:${PORT}"
         elif [ -f _config.yml ]; then  # jekyll
             run_function="bundler_run"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
@@ -354,7 +361,7 @@ case $run_command in
             echo "==="
             echo "Running Django tests"
             echo "==="
-            django_run "${project}-django-test" "" python3 manage.py test || test_error=true
+            python_run "${project}-django-test" "" python3 manage.py test || test_error=true
 
             echo "==="
             echo "Running flake8 tests"
@@ -364,8 +371,15 @@ case $run_command in
                 --volume `pwd`:`pwd` \
                 --workdir `pwd` \
                 --name "${project}-flake8-test" \
-                --entrypoint flake8 \
-                ${django_image} --exclude '*env*,node_modules' || test_error=true
+                ${python_image} flake8 --exclude '*env*,node_modules' || test_error=true
+        fi
+
+        # Generic python tests
+        if [ -f tests.py ]; then
+            echo "==="
+            echo "Running python tests from tests.py"
+            echo "==="
+            python_run "${project}-python-tests" "" python3 tests.py || test_error=true
         fi
 
         if ${test_error}; then
@@ -409,7 +423,7 @@ case $run_command in
             docker volume rm --force ${pip_cache_volume}
         fi
     ;;
-    "django")
+    "python")
         expose_port=""
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
@@ -424,7 +438,7 @@ case $run_command in
             esac
             shift
         done
-        django_run "${project}-django-$(date +'%s')" "${expose_port}" $@
+        python_run "${project}-python-$(date +'%s')" "${expose_port}" $@
     ;;
     "node")
         expose_port=""
@@ -462,3 +476,4 @@ case $run_command in
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Support flask projects. This will be exemplified in snapcraft-flask in a moment.

Also:

- When running inside containers as the host UID, make sure it's actually assigned to a real user
- Make "clean" more robust by always deleting any containers that reference volumes before deleting the volumes
- Use the latest python3 image, which no longer handles dependencies itself. Instead, the run script now checks if dependencies are up-to-date and installs them if needed. This allows us to install pip dependences as root, which is generally more robust.

QA
--

Try out this script in snapcraft.flask and www.ubuntu.com by reviewing the following PRs:

- https://github.com/canonical-websites/snapcraft-flask/pull/13
- https://github.com/canonical-websites/www.ubuntu.com/pull/2171