### PR TITLE
Support for running in Jenkins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,4 +7,5 @@ v0.3.0 (2017-05-21): Intelligently update blocks in gitignore
 v1.0.0 (2017-08-20): Unify run script for all project types
 v1.1.0 (2017-08-31): Manage requirements.txt directly; Add flask support
 v1.1.0 (2017-09-06): Simplify ruby dependencies
-v1.2.0 (2017-09-06): Proxy support
+v1.2.0 (2017-09-22): Proxy support
+v2.0.0 (2017-09-23): Use a single "dev" image; Update package.json commands

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,3 +7,4 @@ v0.3.0 (2017-05-21): Intelligently update blocks in gitignore
 v1.0.0 (2017-08-20): Unify run script for all project types
 v1.1.0 (2017-08-31): Manage requirements.txt directly; Add flask support
 v1.1.0 (2017-09-06): Simplify ruby dependencies
+v1.2.0 (2017-09-06): Proxy support

--- a/generators/run/templates/package.json
+++ b/generators/run/templates/package.json
@@ -1,12 +1,15 @@
 {
   "scripts": {
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "build": "node-sass --include-path node_modules static/sass --output static/css",
-    "watch": "node-sass --include-path node_modules --source-map true --watch static/sass --output static/css",
+    "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer -b 'last 2 versions' < static/css/styles.css | postcss --use cssnano > static/css/styles.min.css",
+    "watch": "watch -p '_sass/*.scss' -c 'yarn run build'",
     "clean": "rm -rf node_modules yarn-error.log static/css *.log *.sqlite _site/ build/ .jekyll-metadata"
   },
   "devDependencies": {
     "node-sass": "^4.5.3",
-    "sass-lint": "^1.10.2"
+    "sass-lint": "^1.10.2",
+    "postcss-cli": "^4.1.0",
+    "cssnano": "3.10.0",
+    "watch-cli": "^0.2.2"
   }
 }

--- a/generators/run/templates/package.json
+++ b/generators/run/templates/package.json
@@ -9,7 +9,7 @@
     "node-sass": "^4.5.3",
     "sass-lint": "^1.10.2",
     "postcss-cli": "^4.1.0",
-    "cssnano": "3.10.0",
+    "cssnano": "^3.10.0",
     "watch-cli": "^0.2.2"
   }
 }

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:332ff57f863d61a872965569014964cf67bcd0dc"
+dev_image="canonicalwebteam/dev:v1.0.0"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi
@@ -100,7 +100,7 @@ else
     echo $project > .docker-project
 fi
 
-# Volume names 
+# Volume names
 cache_volume="${CANONICAL_WEBTEAM_CACHE_VOLUME:-canonical-webteam-cache}"
 etc_volume="${project}-etc"
 usr_local_volume="${project}-usr-local"
@@ -156,7 +156,7 @@ kill_container () {
 
 docker_run () {
     # Get options
-    extra_options="${1}"; shift
+    docker_run_options="${1}"; shift
 
     # Generate container name from command
     container_name="${project}-${@}"
@@ -178,12 +178,12 @@ docker_run () {
         ${env_file}                  `# Pass environment variables into the container, if file exists`  \
         ${http_proxy}                `# Include HTTP proxy if needed`  \
         ${tty}                       `# Attach a pseudo-terminal, if relevant`  \
-        ${extra_options}             `# Extra options`  \
+        ${docker_run_options}        `# Extra options`  \
         ${dev_image} $@              `# Run command in the image`
 }
 
 run_as_user () {
-    extra_options="${1}"; shift
+    run_as_user_options="${1}"; shift
 
     # Create local user and group in the dev image
     uid=$(id -u)
@@ -191,20 +191,20 @@ run_as_user () {
 
     if ! docker volume inspect ${etc_volume} &> /dev/null; then
         etc_run="docker run --rm --volume ${etc_volume}:/etc ${dev_image}"
-        if ! ${etc_run} grep -P '${gid}:$' /etc/group &> /dev/null; then
+        if ! ${etc_run} grep -P "${gid}:$" /etc/group &> /dev/null; then
             ${etc_run} groupadd -g ${gid} app-user
         fi
 
-        if ! ${etc_run} grep -P 'x:${uid}:' /etc/passwd &> /dev/null; then
+        if ! ${etc_run} grep -P "x:${uid}:" /etc/passwd &> /dev/null; then
             ${etc_run} useradd -u ${uid} -g ${gid} app-user
         fi
     fi
 
-    docker_run "--user $(id -u):$(id -g) ${extra_options}" $@
+    docker_run "--user $(id -u):$(id -g) ${run_as_user_options}" $@
 }
 
 python_run () {
-    extra_options="${1}"; shift
+    python_run_options="${1}"; shift
 
     # Update dependencies if required
     if [ -f requirements.txt ]; then
@@ -226,10 +226,10 @@ python_run () {
         if ! docker network inspect ${network_name} &> /dev/null; then
             docker network create ${network_name}
         fi
-        extra_options="${extra_options} --network ${network_name}"
+        python_run_options="${python_run_options} --network ${network_name}"
 
         # Start the database
-        if [[ "${extra_options}" != *"--detach"* ]]; then trap "kill_container ${project}-db" EXIT; fi
+        if [[ "${python_run_options}" != *"--detach"* ]]; then trap "kill_container ${project}-db" EXIT; fi
         if ! docker inspect -f {{.State.Running}} ${db_container} &>/dev/null; then
             docker run \
                 --name ${db_container}       `# Name the container`  \
@@ -258,7 +258,7 @@ python_run () {
     fi
 
     # Run the command in the python docker image
-    run_as_user "--env ${debug} ${extra_options}" $@
+    run_as_user "--env ${debug} ${python_run_options}" $@
 }
 
 # Find current run command

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -64,6 +64,14 @@ RUN_DEBUG=true
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
 module_volumes=()
 
+# Grab HTTP_PROXY settings from the host
+http_proxy=""
+if [ -n "${HTTP_PROXY:-}" ]; then
+    http_proxy="--env HTTP_PROXY=${HTTP_PROXY} --env http_proxy=${HTTP_PROXY}"
+fi
+if [ -n "${HTTPS_PROXY:-}" ]; then
+    http_proxy="${http_proxy} --env HTTPS_PROXY=${HTTPS_PROXY} --env https_proxy=${HTTPS_PROXY}"
+fi
 
 ##
 # Check docker is installed correctly
@@ -144,8 +152,14 @@ create_current_user () {
     gid=$(id -g)
 
     if ! docker volume inspect ${etc_volume} &> /dev/null; then
-        docker run --rm --volume ${etc_volume}:/etc ${image} bash -c "grep -P '${gid}:$' /etc/group &> /dev/null || groupadd -g ${gid} app-user"
-        docker run --rm --volume ${etc_volume}:/etc ${image} bash -c "grep -P 'x:${uid}:' /etc/passwd &> /dev/null || useradd -u ${uid} -g ${gid} app-user"
+        etc_run="docker run --rm --volume ${etc_volume}:/etc ${image}"
+        if ! ${etc_run} grep -P '${gid}:$' /etc/group &> /dev/null; then
+            ${etc_run} groupadd -g ${gid} app-user
+        fi
+
+        if ! ${etc_run} grep -P 'x:${uid}:' /etc/passwd &> /dev/null; then
+            ${etc_run} useradd -u ${uid} -g ${gid} app-user
+        fi
     fi
 }
 
@@ -171,6 +185,7 @@ docker_run () {
         --name ${container_name}  `# Name the container` \
         --rm                      `# Remove the container once it's finished`  \
         ${env_file}               `# Pass environment variables into the container, if file exists`  \
+        ${http_proxy}             `# Include HTTP proxy if needed`  \
         --volume `pwd`:`pwd`      `# Mirror current directory inside container`  \
         --workdir `pwd`           `# Set current directory to the image's work directory`  \
         ${tty}                    `# Attach a pseudo-terminal, if relevant`  \
@@ -287,6 +302,7 @@ python_run () {
                 --name ${db_container}       `# Name the container`  \
                 --rm                         `# Remove the container once it's finished`  \
                 --volume "${db_volume}":/var/lib/postgresql/data  `# Store dependencies in a docker volume`  \
+                ${http_proxy}                `# Include HTTP proxy if needed`  \
                 --network "${network_name}"  `# Use an isolated network`  \
                 --network-alias db           `# Call this container "db" on the network so it can be found`  \
                 --detach                     `# Run in the background` \
@@ -463,6 +479,7 @@ case $run_command in
             echo "==="
             docker run \
                 ${tty} \
+                ${http_proxy}               `# Include HTTP proxy if needed`  \
                 --volume `pwd`:`pwd` \
                 --workdir `pwd` \
                 --name "${project}-flake8-test" \
@@ -498,7 +515,7 @@ case $run_command in
             if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
         done
         echo "- Removing project volumes"
-        if [ -n "${project_volumes}" ]; then docker volume rm --force ${project_volumes}; fi
+        if [ -n "${project_volumes}" ]; then docker volume rm ${project_volumes}; fi
 
         echo "- Removing remaining project containers"
         project_containers="$(docker ps --all --quiet --filter name=${project})"
@@ -516,14 +533,14 @@ case $run_command in
         echo "Removing cache volume ${yarn_cache_volume}"
         containers_using_volume=$(docker ps --quiet --all --filter "volume=${yarn_cache_volume}")
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-        docker volume rm --force ${yarn_cache_volume}
+        docker volume rm ${yarn_cache_volume}
 
         if [ -f manage.py ]; then
             # Clean pip cache volume
             echo "Removing cache volume ${pip_cache_volume}"
             containers_using_volume=$(docker ps --quiet --all --filter "volume=${pip_cache_volume}")
             if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-            docker volume rm --force ${pip_cache_volume}
+            docker volume rm ${pip_cache_volume}
         fi
     ;;
     "python")

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -189,13 +189,13 @@ run_as_user () {
     uid=$(id -u)
     gid=$(id -g)
 
-    if ! docker volume inspect ${etc_volume} &> /dev/null; then
+    if ! docker volume inspect -f "Volume exists: {{.Name}}" ${etc_volume} 2> /dev/null; then
         etc_run="docker run --rm --volume ${etc_volume}:/etc ${dev_image}"
-        if ! ${etc_run} grep -P "${gid}:$" /etc/group &> /dev/null; then
+        if ! ${etc_run} grep -P "${gid}:$" /etc/group; then
             ${etc_run} groupadd -g ${gid} app-user
         fi
 
-        if ! ${etc_run} grep -P "x:${uid}:" /etc/passwd &> /dev/null; then
+        if ! ${etc_run} grep -P "x:${uid}:" /etc/passwd; then
             ${etc_run} useradd -u ${uid} -g ${gid} app-user
         fi
     fi

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -32,9 +32,7 @@ Commands
 - build: Run \`yarn run build\`
 - test: Run \`yarn run test\`
 - stop: Stop any running containers
-- node [-p|--expose-port PORT] <args>: Run a command in the node container (optionally exposing a port to the host)
-- python [-p|--expose-port PORT] <args>: Run a command in a python container (optionally exposing a port to the host)
-- bundler [-p|--expose-port PORT] <args>: Run a command in a bundler container (optionally exposing a port to the host)
+- debug [-p|--expose-port PORT] <args>: Run a command in the development container (optionally exposing a port to the host)
 - clean: Remove all images and containers, any installed dependencies and the .docker-project file
 - clean-cache: Empty cache files, which are saved between projects (eg, yarn)
 "
@@ -44,13 +42,10 @@ Commands
 ##
 
 # Define docker images versions
-python_image="canonicalwebteam/python3:v1.1.0"
-ruby_image="canonicalwebteam/ruby:v0.1.1"
-node_image="canonicalwebteam/node:v0.2.1"
-
-# Global volume names
-yarn_cache_volume="${CANONICAL_WEBTEAM_YARN_CACHE_VOLUME:-canonical-webteam-node-cache}"
-pip_cache_volume="${CANONICAL_WEBTEAM_PIP_CACHE_VOLUME:-canonical-webteam-pip-cache}"
+dev_image="canonicalwebteam/dev:332ff57f863d61a872965569014964cf67bcd0dc"
+if [ -n "${DOCKER_REGISTRY:-}" ]; then
+    dev_image="${DOCKER_REGISTRY}/${dev_image}"
+fi
 
 # Interactivity options
 [ -t 1 ] && tty="--tty --interactive" || tty=""           # Do we have a terminal?
@@ -63,15 +58,6 @@ RUN_DEBUG=true
 # Other variables
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
 module_volumes=()
-
-# Grab HTTP_PROXY settings from the host
-http_proxy=""
-if [ -n "${HTTP_PROXY:-}" ]; then
-    http_proxy="--env HTTP_PROXY=${HTTP_PROXY} --env http_proxy=${HTTP_PROXY}"
-fi
-if [ -n "${HTTPS_PROXY:-}" ]; then
-    http_proxy="${http_proxy} --env HTTPS_PROXY=${HTTPS_PROXY} --env https_proxy=${HTTPS_PROXY}"
-fi
 
 ##
 # Check docker is installed correctly
@@ -95,6 +81,15 @@ if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then
     exit 1
 fi
 
+# Grab HTTP_PROXY settings from the host
+http_proxy=""
+if [ -n "${HTTP_PROXY:-}" ]; then
+    http_proxy="--env HTTP_PROXY=${HTTP_PROXY} --env http_proxy=${HTTP_PROXY}"
+fi
+if [ -n "${HTTPS_PROXY:-}" ]; then
+    http_proxy="${http_proxy} --env HTTPS_PROXY=${HTTPS_PROXY} --env https_proxy=${HTTPS_PROXY}"
+fi
+
 # Generate the project name
 if [[ -f ".docker-project" ]]; then
     project=$(cat .docker-project)
@@ -105,13 +100,17 @@ else
     echo $project > .docker-project
 fi
 
-# Set project specific container names
-python_local_volume="${project}-python-local"
-ruby_local_volume="${project}-ruby-local"
+# Volume names 
+cache_volume="${CANONICAL_WEBTEAM_CACHE_VOLUME:-canonical-webteam-cache}"
+etc_volume="${project}-etc"
+usr_local_volume="${project}-usr-local"
+db_volume="${project}-db"
+
+# Container names
 db_container="${project}-db"
 pip_container="${project}-pip"
-gem_container="${project}-gem"
-db_volume="${project}-db"
+
+# Network name
 network_name="${project}-net"
 
 # Import environment settings
@@ -145,24 +144,6 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     shift
 done
 
-create_current_user () {
-    image="${1}"
-    etc_volume="${2}"
-    uid=$(id -u)
-    gid=$(id -g)
-
-    if ! docker volume inspect ${etc_volume} &> /dev/null; then
-        etc_run="docker run --rm --volume ${etc_volume}:/etc ${image}"
-        if ! ${etc_run} grep -P '${gid}:$' /etc/group &> /dev/null; then
-            ${etc_run} groupadd -g ${gid} app-user
-        fi
-
-        if ! ${etc_run} grep -P 'x:${uid}:' /etc/passwd &> /dev/null; then
-            ${etc_run} useradd -u ${uid} -g ${gid} app-user
-        fi
-    fi
-}
-
 kill_container () {
     container_name="${1}"
 
@@ -175,100 +156,55 @@ kill_container () {
 
 docker_run () {
     # Get options
-    container_name=${1}; shift  # Get container_name as first argument
+    extra_options="${1}"; shift
+
+    # Generate container name from command
+    container_name="${project}-${@}"
+    container_name="${container_name// /_}"  # Replace spaces with underscores
+    container_name=$(echo ${container_name} | tr -dc '[:alnum:]_.-')  # Remove disallowed chars
 
     # Kill existing containers
     kill_container "${container_name}"
 
     # Start the new container
     docker run  \
-        --name ${container_name}  `# Name the container` \
-        --rm                      `# Remove the container once it's finished`  \
-        ${env_file}               `# Pass environment variables into the container, if file exists`  \
-        ${http_proxy}             `# Include HTTP proxy if needed`  \
-        --volume `pwd`:`pwd`      `# Mirror current directory inside container`  \
-        --workdir `pwd`           `# Set current directory to the image's work directory`  \
-        ${tty}                    `# Attach a pseudo-terminal, if relevant`  \
-        $@                        `# Extra arguments`
+        --name ${container_name}     `# Name the container` \
+        --rm                         `# Remove the container once it's finished`  \
+        --volume `pwd`:`pwd`         `# Mirror current directory inside container`  \
+        --workdir `pwd`              `# Set current directory to the image's work directory`  \
+        --volume ${etc_volume}:/etc  `# Use etc with corresponding user added`  \
+        --volume ${usr_local_volume}:/usr/local/       `# Bind local folder to volume`  \
+        --volume ${cache_volume}:/home/shared/.cache/  `# Bind cache to volume` \
+        ${env_file}                  `# Pass environment variables into the container, if file exists`  \
+        ${http_proxy}                `# Include HTTP proxy if needed`  \
+        ${tty}                       `# Attach a pseudo-terminal, if relevant`  \
+        ${extra_options}             `# Extra options`  \
+        ${dev_image} $@              `# Run command in the image`
 }
 
-ruby_run () {
-    container_name="${1}"; shift
-    extra_options="${1:-}"; shift
+run_as_user () {
+    extra_options="${1}"; shift
 
-    # Kill existing containers
-    kill_container "${container_name}"
+    # Create local user and group in the dev image
+    uid=$(id -u)
+    gid=$(id -g)
 
-    # Create etc volume with the new user
-    create_current_user "${ruby_image}" "${project}-bundler-etc"
-
-    # Update dependencies if required
-    if [ -f Gemfile ]; then
-        if type md5sum &> /dev/null; then
-            gemfile_hash=$(md5sum Gemfile | awk '{print $1;}')
-        else
-            gemfile_hash=$(md5 Gemfile | awk '{print $4;}')
+    if ! docker volume inspect ${etc_volume} &> /dev/null; then
+        etc_run="docker run --rm --volume ${etc_volume}:/etc ${dev_image}"
+        if ! ${etc_run} grep -P '${gid}:$' /etc/group &> /dev/null; then
+            ${etc_run} groupadd -g ${gid} app-user
         fi
 
-        if [ ! -f ".gemfile.${project}.hash" ] || [ "$(cat .gemfile.${project}.hash)" != "${gemfile_hash}" ]; then
-            echo "Updating dependencies from Gemfile:" >> /dev/stderr
-            docker_run "${gem_container}" \
-                --volume ${ruby_local_volume}:/usr/local  `# Store dependencies in a docker volume`  \
-                ${ruby_image} bundle install               # Install new dependencies
-            echo -n "${gemfile_hash}" > .gemfile.${project}.hash
+        if ! ${etc_run} grep -P 'x:${uid}:' /etc/passwd &> /dev/null; then
+            ${etc_run} useradd -u ${uid} -g ${gid} app-user
         fi
     fi
 
-    # Run a command in the "bundler" image
-    docker_run "${container_name}" \
-        --user $(id -u):$(id -g)                  `# Use the current user`  \
-        --volume ${project}-bundler-etc:/etc      `# Use etc with corresponding user added`  \
-        --volume ${ruby_local_volume}:/usr/local  `# Persist ruby dependencies in a docker volume`  \
-        ${extra_options}                          `# Extra options`  \
-        ${ruby_image} $@                       `# Run the jeklyll command`
-}
-
-node_run () {
-    # Standard options for running node commands
-    container_name="${1}"; shift
-    extra_options="${1:-}"; shift
-
-    # Create etc volume with the new user
-    create_current_user "${node_image}" "${project}-node-etc"
-
-    # Run a command in the "node" image
-    docker_run "${container_name}" \
-        --user $(id -u):$(id -g)                                 `# Use the current user`  \
-        --volume ${project}-node-etc:/etc                        `# Use etc with corresponding user added`  \
-        --volume ${yarn_cache_volume}:/home/shared/.cache/yarn/  `# Bind cache to volume` \
-        ${module_volumes[@]+"${module_volumes[@]}"}              `# Add any override modules as volumes`  \
-        ${extra_options}                                         `# Extra options`  \
-        ${node_image} ${@}                                       `# Run command in node image`
-}
-
-node_install () {
-    # Install bower dependencies, if we need to
-    if [ -f "bower.json" ]; then
-        node_run "${project}-bower-install" "" bower install
-    fi
-
-    # Create etc volume with the new user
-    create_current_user "${node_image}" "${project}-node-etc"
-
-    # Run a command in the "node" image
-    docker_run "${project}-yarn-install"  \
-        --user $(id -u):$(id -g)                                 `# Use the current user`  \
-        --volume ${project}-node-etc:/etc                        `# Use etc with corresponding user added`  \
-        --volume ${yarn_cache_volume}:/home/shared/.cache/yarn/  `# Bind yarn cache to volume` \
-        ${node_image} yarn install                               `# Install yarn dependencies`
+    docker_run "--user $(id -u):$(id -g) ${extra_options}" $@
 }
 
 python_run () {
-    container_name="${1}"; shift
-    extra_options="${1:-}"; shift
-
-    # Create etc volume with the new user
-    create_current_user "${python_image}" "${project}-python-etc"
+    extra_options="${1}"; shift
 
     # Update dependencies if required
     if [ -f requirements.txt ]; then
@@ -280,10 +216,7 @@ python_run () {
 
         if [ ! -f ".requirements.${project}.hash" ] || [ "$(cat .requirements.${project}.hash)" != "${requirements_hash}" ]; then
             echo "Updating dependencies from requirements.txt:" >> /dev/stderr
-            docker_run "${pip_container}" \
-                --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
-                --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
-                ${python_image} pip3 install --requirement requirements.txt  # Install new dependencies
+            docker_run "" pip3 install --requirement requirements.txt  # Install new dependencies
             echo -n "${requirements_hash}" > .requirements.${project}.hash
         fi
     fi
@@ -302,7 +235,7 @@ python_run () {
                 --name ${db_container}       `# Name the container`  \
                 --rm                         `# Remove the container once it's finished`  \
                 --volume "${db_volume}":/var/lib/postgresql/data  `# Store dependencies in a docker volume`  \
-                ${http_proxy}                `# Include HTTP proxy if needed`  \
+                 ${http_proxy}               `# Include HTTP proxy if needed`  \
                 --network "${network_name}"  `# Use an isolated network`  \
                 --network-alias db           `# Call this container "db" on the network so it can be found`  \
                 --detach                     `# Run in the background` \
@@ -311,13 +244,7 @@ python_run () {
 
         # Provision database for django sites
         if [ -f manage.py ]; then
-            # Run a command in the "node" image
-            docker_run "${container_name}" \
-                --user $(id -u):$(id -g)                               `# Use the current user`  \
-                --volume ${project}-python-etc:/etc                    `# Use etc with corresponding user added`  \
-                --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
-                --network "${network_name}"                            `# Use an isolated network`  \
-                ${python_image} python3 manage.py migrate              `# Run command in the Python image`
+            docker_run "--network ${network_name}" python3 manage.py migrate
         fi
 
     fi
@@ -331,14 +258,7 @@ python_run () {
     fi
 
     # Run the command in the python docker image
-    docker_run ${container_name} \
-        --user $(id -u):$(id -g)                               `# Use the current user`  \
-        --volume ${project}-python-etc:/etc                    `# Use etc with corresponding user added`  \
-        --volume ${python_local_volume}:/usr/local/            `# Store dependencies in a docker volume`  \
-        --env PORT=${PORT}                                     `# Set the port correctly`  \
-        --env ${debug}                                         `# Set debug mode`  \
-        ${extra_options}                                       `# Any extra docker options`  \
-        ${python_image} $@                                     `# Run command in the Python image`
+    run_as_user "--env ${debug} ${extra_options}" $@
 }
 
 # Find current run command
@@ -369,18 +289,18 @@ case $run_command in
 
         # Setup yarn dependencies
         if [ -f package.json ]; then
-            node_install
-            node_run "${project}-build" "" yarn run build
+            run_as_user "" yarn install
+            run_as_user "" yarn run build
         fi
 
         # Run watch command in the background
         if ${run_watcher}; then
             if [ -z "${detach}" ];  then trap "kill_container ${project}-watch" EXIT; fi
-            node_run "${project}-watch" "--detach" yarn run watch  # Run watch in the background
+            run_as_user "--detach" yarn run watch  # Run watch in the background
         fi
 
         # Select run function and run command
-        run_function="node_run"
+        run_function="run_as_user"
         run_command="yarn run serve"
         run_options=""
         if [ -f manage.py ]; then  # django
@@ -391,12 +311,12 @@ case $run_command in
             run_command="flask run --host 0.0.0.0 --port ${PORT}"
             run_options="--env FLASK_APP=app.py"
         elif [ -f _config.yml ]; then  # jekyll
-            run_function="ruby_run"
+            run_function="run_as_user"
             run_command="jekyll serve -P ${PORT} -H 0.0.0.0"
         fi
 
         # Run the serve container, publishing the port, and detaching if required
-        ${run_function} "${project}-serve" "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
+        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"
@@ -424,66 +344,46 @@ case $run_command in
         done
         if ${watch_site}; then
             trap "kill_container ${project}-watch-site" EXIT
-            ruby_run "${project}-watch-site" "--detach" jekyll build --watch  # Run site watcher in the background
+            run_as_user "--detach" jekyll build --watch  # Run site watcher in the background
         fi
-        node_install
-        node_run "${project}-build" "" yarn run build
-        node_run "${project}-watch" "" yarn run watch
+        run_as_user "" yarn install
+        run_as_user "" yarn run build
+        run_as_user "" yarn run watch
     ;;
     "build")
-        node_install
-        node_run "${project}-build" "" yarn run build
+        run_as_user "" yarn install
+        run_as_user "" yarn run build
         if [ -f _config.yml ]; then
             # For jekyll sites
-            ruby_run "${project}-build-site" "" jekyll build
+            run_as_user "" jekyll build
         fi
     ;;
     "test")
-        node_install
-
         test_error=false
-
-        kill_container "${project}-node-test"
-        kill_container "${project}-django-test"
-        kill_container "${project}-python-test"
-        kill_container "${project}-flake8-test"
 
         # Run node tests
         if [ -f package.json ]; then
-            echo "==="
-            echo "Running yarn tests"
-            echo "==="
-            node_run "${project}-node-test" "" yarn run test || test_error=true
+            echo "- Running yarn tests"
+            run_as_user "" yarn install
+            run_as_user "" yarn run test || test_error=true
         fi
 
         # Run django tests
         if [ -f manage.py ]; then
-            echo "==="
-            echo "Running Django tests"
-            echo "==="
-            python_run "${project}-django-test" "" python3 manage.py test || test_error=true
+            echo "- Running Django tests"
+            python_run "" python3 manage.py test || test_error=true
         fi
 
         # Generic python tests
         if [ -f tests.py ]; then
-            echo "==="
-            echo "Running python tests from tests.py"
-            echo "==="
-            python_run "${project}-python-test" "" python3 tests.py || test_error=true
+            echo "- Running python tests from tests.py"
+            python_run "" python3 tests.py || test_error=true
         fi
 
         # Run flake8 (python syntax) checks
         if [ -f manage.py ] || [ -f app.py ] || [ -f tests.py ]; then
-            echo "==="
-            echo "Running flake8 tests"
-            echo "==="
-            docker run \
-                ${tty} \
-                ${http_proxy}               `# Include HTTP proxy if needed`  \
-                --volume `pwd`:`pwd` \
-                --workdir `pwd` \
-                --name "${project}-flake8-test" \
-                ${python_image} flake8 --exclude '*env*,node_modules' || test_error=true
+            echo "- Running flake8 tests"
+            python_run "" flake8 --exclude '*env*,node_modules' || test_error=true
         fi
 
         # Report success or failure
@@ -503,7 +403,7 @@ case $run_command in
         rm -rf .requirements.${project}.hash .gemfile.${project}.hash
 
         echo "Running 'clean' yarn script"
-        node_run "${project}-clean" "" yarn run clean || true  # Run the clean script
+        run_as_user "" yarn run clean || true  # Run the clean script
 
         echo "Removing docker objects for project: ${project}"
 
@@ -530,20 +430,12 @@ case $run_command in
     ;;
     "clean-cache")
         # Clean node cache volume
-        echo "Removing cache volume ${yarn_cache_volume}"
-        containers_using_volume=$(docker ps --quiet --all --filter "volume=${yarn_cache_volume}")
+        echo "Removing cache volume ${cache_volume}"
+        containers_using_volume=$(docker ps --quiet --all --filter "volume=${cache_volume}")
         if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-        docker volume rm ${yarn_cache_volume}
-
-        if [ -f manage.py ]; then
-            # Clean pip cache volume
-            echo "Removing cache volume ${pip_cache_volume}"
-            containers_using_volume=$(docker ps --quiet --all --filter "volume=${pip_cache_volume}")
-            if [ -n "${containers_using_volume}" ]; then docker rm --force ${containers_using_volume}; fi
-            docker volume rm ${pip_cache_volume}
-        fi
+        docker volume rm ${cache_volume}
     ;;
-    "python")
+    "debug")
         expose_port=""
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
@@ -558,41 +450,7 @@ case $run_command in
             esac
             shift
         done
-        python_run "${project}-python-$(date +'%s')" "${expose_port}" $@
-    ;;
-    "node")
-        expose_port=""
-        while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
-            key="$1"
-
-            case $key in
-                -p|--expose-port)
-                    if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
-                    expose_port="--publish ${2}:${2}"
-                    shift
-                ;;
-                *) invalid "Option '${key}' not recognised." ;;
-            esac
-            shift
-        done
-        node_run "${project}-node-$(date +'%s')" "${expose_port}" $@
-    ;;
-    "bundler")
-        expose_port=""
-        while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
-            key="$1"
-
-            case $key in
-                -p|--expose-port)
-                    if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
-                    expose_port="--publish ${2}:${2}"
-                    shift
-                ;;
-                *) invalid "Option '${key}' not recognised." ;;
-            esac
-            shift
-        done
-        ruby_run "${project}-bundler-$(date +'%s')" "${expose_port}" $@
+        run_as_user "${expose_port}" $@
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
- Update the ./run script to include proxy support - this is so it'll pick up on `HTTP_PROXY` and `HTTPS_PROXY` variables for building inside restricted jenkins environments.
- Base everything off [canonicalwebteam/dev](https://github.com/canonical-webteam/docker-dev), that is in turn based on `ubuntu:xenial`
- Driveby: Update the default `yarn run build` command to do autoprefixing and minification, and `yarn run watch` to run the same as `build`

This can be version 2.0.0.

Fixes #39

QA
--

Review https://github.com/canonical-websites/snapcraft-flask/pull/62