### PR TITLE
v2.1.1: Provide COMMIT_ID variable to running containers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,4 +9,5 @@ v1.1.0 (2017-08-31): Manage requirements.txt directly; Add flask support
 v1.1.0 (2017-09-06): Simplify ruby dependencies
 v1.2.0 (2017-09-22): Proxy support
 v2.0.0 (2017-09-23): Use a single "dev" image; Update package.json commands
-v2.1.0 (2017-09-23): Support for bundler; Change "debug" to "exec"; Better package.json defaults
+v2.1.0 (2017-09-29): Support for bundler; Change "debug" to "exec"; Better package.json defaults
+v2.1.1 (2017-09-30): Provide COMMIT_ID environment variable in running containers

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -166,6 +166,9 @@ docker_run () {
     # Kill existing containers
     kill_container "${container_name}"
 
+    # Environment info
+    commit_id=$(git rev-parse HEAD || echo "unknown")
+
     # Start the new container
     docker run  \
         --name ${container_name}     `# Name the container` \
@@ -175,6 +178,7 @@ docker_run () {
         --volume ${etc_volume}:/etc  `# Use etc with corresponding user added`  \
         --volume ${usr_local_volume}:/usr/local/       `# Bind local folder to volume`  \
         --volume ${cache_volume}:/home/shared/.cache/  `# Bind cache to volume` \
+        --env COMMIT_ID=${commit_id} `# Pass through the commit ID` \
         ${env_file}                  `# Pass environment variables into the container, if file exists`  \
         ${http_proxy}                `# Include HTTP proxy if needed`  \
         ${tty}                       `# Attach a pseudo-terminal, if relevant`  \

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -193,7 +193,7 @@ run_as_user () {
     uid=$(id -u)
     gid=$(id -g)
 
-    if ! docker volume inspect -f "Volume exists: {{.Name}}" ${etc_volume} 2> /dev/null; then
+    if ! docker volume inspect -f " " ${etc_volume} 2> /dev/null; then
         etc_run="docker run --rm --volume ${etc_volume}:/etc ${dev_image}"
         if ! ${etc_run} grep -P "${gid}:$" /etc/group; then
             ${etc_run} groupadd -g ${gid} app-user

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
This is to make the environment more similar to how we hope to run our services in production - so they application has the option of consuming the COMMIT_ID environment variable, e.g. for exposing it as an HTTP header.

Also update to v2.1.1

QA
--

See:

- https://github.com/canonical-websites/snapcraft.io/pull/78
- https://github.com/canonical-websites/www.ubuntu.com/pull/2253
- https://github.com/CanonicalLtd/snappy-docs/pull/125