### PR TITLE
Run Bower install for dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,3 +11,4 @@ v1.2.0 (2017-09-22): Proxy support
 v2.0.0 (2017-09-23): Use a single "dev" image; Update package.json commands
 v2.1.0 (2017-09-29): Support for bundler; Change "debug" to "exec"; Better package.json defaults
 v2.1.1 (2017-09-30): Provide COMMIT_ID environment variable in running containers
+v2.2.0 (2017-11-03): Add Bower dependency management

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.1.0"
+dev_image="canonicalwebteam/dev:v1.2.0"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi
@@ -279,6 +279,7 @@ has_file_changed() {
 update_dependencies() {
     has_file_changed yarn.lock && yarnlock_changed=true || yarnlock_changed=false
     has_file_changed package.json && packagejson_changed=true || packagejson_changed=false
+    has_file_changed bower.json && bowerjson_changed=true || bowerjson_changed=false
     has_file_changed Gemfile && gemfile_changed=true || gemfile_changed=false
     has_file_changed Gemfile.lock && gemfilelock_changed=true || gemfilelock_changed=false
     has_file_changed requirements.txt && requirements_changed=true || requirements_changed=false
@@ -286,6 +287,11 @@ update_dependencies() {
     # Yarn
     if ${packagejson_changed} || ${yarnlock_changed}; then
         run_as_user "" yarn install
+    fi
+
+    # Bower
+    if ${bowerjson_changed}; then
+        run_as_user "" bower install
     fi
 
     # Ruby bundler

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Add a Bower dependency check while install dependencies.
This is for Ubuntu Tutorials which has a hard dependency on Bower.

This will check for bower.json and run `bower install` as needed.

# QA

Review https://github.com/canonical-websites/tutorials.ubuntu.com/pull/396