### PR TITLE
Check if containers exist before trying to stop them

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -366,6 +366,10 @@ case $run_command in
     "stop")
         echo "Stopping all running containers for ${project}"
         running_containers="$(docker ps --quiet --filter name=${project})"
+        if [ -z "${running_containers}" ]; then
+            echo "No running containers found"
+            exit 0
+        fi
         docker kill ${running_containers}
     ;;
     "watch")


### PR DESCRIPTION
When running `./run stop`, check that containers exist before trying to run docker kill with no arguments.

Fixes #49 

## QA

- Clone this repo
- `npm install -g .` to install the local folder in your system
- Pick your favourite ./run repo (eg, www.ubuntu.com) and run the following inside:
  - `yo canonical-webteam:run` and update the run script
  - `./run serve --detached`
  - `./run stop` - Should kill the background containers
  - `./run stop` (again) - Should say there are no background containers