### PR TITLE
Explicitly set Yarn proxy

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -83,11 +83,14 @@ fi
 
 # Grab HTTP_PROXY settings from the host
 http_proxy=""
+yarn_proxy=""
 if [ -n "${HTTP_PROXY:-}" ]; then
     http_proxy="--env HTTP_PROXY=${HTTP_PROXY} --env http_proxy=${HTTP_PROXY}"
+    yarn_proxy="--proxy ${HTTP_PROXY}"
 fi
 if [ -n "${HTTPS_PROXY:-}" ]; then
     http_proxy="${http_proxy} --env HTTPS_PROXY=${HTTPS_PROXY} --env https_proxy=${HTTPS_PROXY}"
+    yarn_proxy="${yarn_proxy} --https-proxy ${HTTPS_PROXY}"
 fi
 
 # Generate the project name
@@ -286,7 +289,7 @@ update_dependencies() {
 
     # Yarn
     if ${packagejson_changed} || ${yarnlock_changed}; then
-        run_as_user "" yarn install
+        run_as_user "" yarn install ${yarn_proxy}
     fi
 
     # Bower


### PR DESCRIPTION
Yarn is sometimes failing to pick up proxy settings.
While testing locally in a environment with no internet access, it correctly picked up the Proxy. But the repository checkout in the build server did not.

This PR explicitly sets Yarn's proxy setting with `yarn install --proxy PROXY --https-proxy PROXY`. I have tested it on the build server and it works correctly.

## QA

- Clone this repo
- `npm install -g .` to install the local folder in your system
- Pick your favourite ./run repo (eg, www.ubuntu.com) and run the following inside:
  - `yo canonical-webteam:run` and update the run script
  - `./run clean && ./run clean-cache`
  - ` HTTP_PROXY=http://nope HTTPS_PROXY=http://nope ./run build` - Should time out because of the fake proxy address
  - `./run build` - Should work

Optionally, you can set real proxy values to test if you have one available to test with.