### PR TITLE
Environment variables set in correct order

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -55,6 +55,11 @@ fi
 PORT=8000
 RUN_DEBUG=true
 
+# Import environment settings
+if [ -f .env ]; then
+    source .env
+fi
+
 # Other variables
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
 module_volumes=()
@@ -115,11 +120,6 @@ pip_container="${project}-pip"
 
 # Network name
 network_name="${project}-net"
-
-# Import environment settings
-if [ -f .env ]; then
-    export $(cat .env | grep -v ^\# | xargs)
-fi
 
 invalid() {
     message=${1}

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -363,8 +363,17 @@ case $run_command in
             run_command="bundle exec jekyll serve -P ${PORT} -H 0.0.0.0"
         fi
 
+        publish_extra_ports=""
+        if [ -n "${EXTRA_PORTS:-}" ]; then
+            IFS=', ' read -r -a ports_array <<< "$EXTRA_PORTS"
+            for extra_port in "${ports_array[@]}"
+            do
+                publish_extra_ports="${publish_extra_ports} --publish $extra_port:$extra_port"
+            done
+        fi
+
         # Run the serve container, publishing the port, and detaching if required
-        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
+        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Make sure that all environment variables are seted in the correct order.

The bug came from this variable: `run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"` who was setted before the export of the .env file.
