### PR TITLE
Add env local to enviroments file

### DIFF
--- a/generators/run/templates/gitignore
+++ b/generators/run/templates/gitignore
@@ -50,6 +50,7 @@ _site/
 .docker-project
 .*.hash
 .envrc
+.env.local
 env/
 env[23]/
 

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -50,6 +50,7 @@ fi
 # Interactivity options
 [ -t 1 ] && tty="--tty --interactive" || tty=""           # Do we have a terminal?
 [ -f .env ] && env_file="--env-file .env" || env_file=""  # Do we have an env file?
+[ -f .env.local ] && env_file="${env_file} --env-file .env.local" || env_file=env_file  # Do we have a local env file?
 
 # Defaults environment settings
 PORT=8000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Add a `.env.local` so that we can generate new envoriment files and still being ignored by git.

You can see in this project: https://github.com/canonical-websites/build.snapcraft.io/pull/1022
- `.env` file needs to be pushed
- `.env.local` will have some informations like token sercrets etc. generated by our setup script