### PR TITLE
2.6.2: Allow multiple exposed ports in exec; Fix module volumes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,3 +15,4 @@ v2.2.0 (2017-11-03): Add Bower dependency management
 v2.4.1 (2017-12-14): Add local environment file to share secrets
 v2.5.0 (2017-12-19): Update docker image to 1.4
 v2.6.0 (2018-02-12): Fix module volumes; Allow exporting multiple ports in exec
+v2.6.1 (2018-02-12): Optional environment variables for exec

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,3 +13,5 @@ v2.1.0 (2017-09-29): Support for bundler; Change "debug" to "exec"; Better packa
 v2.1.1 (2017-09-30): Provide COMMIT_ID environment variable in running containers
 v2.2.0 (2017-11-03): Add Bower dependency management
 v2.4.1 (2017-12-14): Add local environment file to share secrets
+v2.5.0 (2017-12-19): Update docker image to 1.4
+v2.6.0 (2018-02-12): Fix module volumes; Allow exporting multiple ports in exec

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,3 +17,4 @@ v2.5.0 (2017-12-19): Update docker image to 1.4
 v2.6.0 (2018-02-12): Fix module volumes; Allow exporting multiple ports in exec
 v2.6.1 (2018-02-12): Optional environment variables for exec
 v2.6.2 (2018-02-12): Rename --expose-ports to --expose-port
+v2.6.3 (2018-02-15): Prevent module volumes from creating directories as root

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,3 +16,4 @@ v2.4.1 (2017-12-14): Add local environment file to share secrets
 v2.5.0 (2017-12-19): Update docker image to 1.4
 v2.6.0 (2018-02-12): Fix module volumes; Allow exporting multiple ports in exec
 v2.6.1 (2018-02-12): Optional environment variables for exec
+v2.6.2 (2018-02-12): Rename --expose-ports to --expose-port

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -516,7 +516,7 @@ case $run_command in
             key="$1"
 
             case $key in
-                -p|--expose-ports)
+                -p|--expose-port)
                     if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
                     expose_ports="${expose_ports} --publish ${2}:${2}"
                     shift

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -510,21 +510,21 @@ case $run_command in
         docker volume rm ${cache_volume}
     ;;
     "exec")
-        expose_port=""
+        expose_ports=""
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
 
             case $key in
-                -p|--expose-port)
+                -p|--expose-ports)
                     if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
-                    expose_port="--publish ${2}:${2}"
+                    expose_ports="${expose_ports} --publish ${2}:${2}"
                     shift
                 ;;
                 *) invalid "Option '${key}' not recognised." ;;
             esac
             shift
         done
-        run_as_user "${expose_port}" $@
+        run_as_user "${expose_ports}" $@
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -138,6 +138,10 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
         --no-debug) RUN_DEBUG=false ;;
         -m|--node-module)
             if [ -z "${2:-}" ]; then invalid "Missing module name. Usage: --node-module <path-to-module>."; fi
+            # Ensure directories exist, ready to host module volumes
+            if [ ! -d "`pwd`/node_modules/$(basename ${2})" ]; then
+                mkdir -p "`pwd`/node_modules/$(basename ${2})"
+            fi
             module_volumes="${module_volumes} --volume=${2}:`pwd`/node_modules/$(basename ${2})"
             shift
         ;;

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -63,7 +63,7 @@ fi
 
 # Other variables
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
-module_volumes=()
+module_volumes=""
 
 ##
 # Check docker is installed correctly
@@ -138,7 +138,7 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
         --no-debug) RUN_DEBUG=false ;;
         -m|--node-module)
             if [ -z "${2:-}" ]; then invalid "Missing module name. Usage: --node-module <path-to-module>."; fi
-            module_volumes+=("--volume" "${2}":"`pwd`/node_modules/$(basename ${2})")
+            module_volumes="${module_volumes} --volume=${2}:`pwd`/node_modules/$(basename ${2})"
             shift
         ;;
         -h|--help) echo "$USAGE"; exit ;;
@@ -185,6 +185,7 @@ docker_run () {
         --env COMMIT_ID=${commit_id} `# Pass through the commit ID` \
         ${env_file}                  `# Pass environment variables into the container, if file exists`  \
         ${http_proxy}                `# Include HTTP proxy if needed`  \
+        ${module_volumes}            `# Add module volumes`  \
         ${tty}                       `# Attach a pseudo-terminal, if relevant`  \
         ${docker_run_options}        `# Extra options`  \
         ${dev_image} $@              `# Run command in the image`

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -511,6 +511,7 @@ case $run_command in
     ;;
     "exec")
         expose_ports=""
+        env_vars=""
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
 
@@ -520,11 +521,16 @@ case $run_command in
                     expose_ports="${expose_ports} --publish ${2}:${2}"
                     shift
                 ;;
+                -e|--env)
+                    if [ -z "${2:-}" ]; then invalid "Missing environment variables. Usage: --env XXXX=yyyy"; fi
+                    env_vars="${env_vars} --env ${2}"
+                    shift
+                ;;
                 *) invalid "Option '${key}' not recognised." ;;
             esac
             shift
         done
-        run_as_user "${expose_ports}" $@
+        run_as_user "${expose_ports} ${env_vars}" $@
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
QA
--

**Module volumes**

Get yourself a checkout of [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework/) which contains an obvious change that will effect the styling of www.ubuntu.com.

Now run the site with:

``` bash
./run --node-module $HOME/{path-to-projects-folder}/vanilla-framework
.. or ..
./run -m $HOME/{path-to-projects-folder}/vanilla-framework
```

Visit the site on http://0.0.0.0:8001 and check it's clearly running your version of vanilla-framework

**Expose multiple ports**

Check you can expose multiple ports from a container:

``` bash
./run build  # Make sure dependencies are installed, to make Will happy
./run exec --env SOME_VAR=hello --export-port 8001 -p 8901
$ echo $SOME_VAR
$ ./manage.py runserver 0.0.0.0:8001 & ./manage.py runserver 0.0.0.0:8901
```

Check you can access the site both at http://0.0.0.0:8001 and http://0.0.0.0:8901.