### PR TITLE
Improve dependency management

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,3 +18,4 @@ v2.6.0 (2018-02-12): Fix module volumes; Allow exporting multiple ports in exec
 v2.6.1 (2018-02-12): Optional environment variables for exec
 v2.6.2 (2018-02-12): Rename --expose-ports to --expose-port
 v2.6.3 (2018-02-15): Prevent module volumes from creating directories as root
+v2.7.0 (2018-02-15): Improved dependency checking

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -189,7 +189,6 @@ docker_run () {
         --env COMMIT_ID=${commit_id} `# Pass through the commit ID` \
         ${env_file}                  `# Pass environment variables into the container, if file exists`  \
         ${http_proxy}                `# Include HTTP proxy if needed`  \
-        ${module_volumes}            `# Add module volumes`  \
         ${tty}                       `# Attach a pseudo-terminal, if relevant`  \
         ${docker_run_options}        `# Extra options`  \
         ${dev_image} $@              `# Run command in the image`
@@ -263,61 +262,70 @@ create_etc_volume() {
     fi
 }
 
-has_file_changed() {
-    file_to_check=$1
-    hash_file=".${file_to_check}.${project}.hash"
-
-    if [ -f ${file_to_check} ]; then
-        if [ -f "${hash_file}" ]; then
-            saved_hash="$(cat ${hash_file})"
-        else
-            saved_hash=""
-        fi
-
-        if type md5sum &> /dev/null; then
-            new_hash=$(md5sum ${file_to_check} | awk '{print $1;}')
-        else
-            new_hash=$(md5 ${file_to_check} | awk '{print $4;}')
-        fi
-
-        if [ "${saved_hash}" != "${new_hash}" ]; then
-            echo -n "${new_hash}" > ${hash_file}
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
 update_dependencies() {
-    has_file_changed yarn.lock && yarnlock_changed=true || yarnlock_changed=false
-    has_file_changed package.json && packagejson_changed=true || packagejson_changed=false
-    has_file_changed bower.json && bowerjson_changed=true || bowerjson_changed=false
-    has_file_changed Gemfile && gemfile_changed=true || gemfile_changed=false
-    has_file_changed Gemfile.lock && gemfilelock_changed=true || gemfilelock_changed=false
-    has_file_changed requirements.txt && requirements_changed=true || requirements_changed=false
-
     # Make sure the etc volume has been created first
     create_etc_volume
 
-    # Yarn
-    if ${packagejson_changed} || ${yarnlock_changed}; then
-        run_as_user "" yarn install ${yarn_proxy}
+    # Install yarn dependencies
+    if [ -f package.json ]; then
+        package_json_hash=$(md5sum package.json | cut -f 1 -d " ")
+        if [ -d node_modules ]; then
+            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${package_json_hash}
+        fi
+        if [ -z "${yarn_dependencies_hash:-}" ] || [ ! -f .yarn.${project}.hash ] || [ "${yarn_dependencies_hash}" != "$(cat .yarn.${project}.hash)" ]; then
+            echo "Installing new Yarn dependencies"
+            run_as_user "" yarn install --force ${yarn_proxy}
+            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${package_json_hash}
+            echo ${yarn_dependencies_hash} > .yarn.${project}.hash
+        else
+            echo "Yarn dependencies haven't changed. To force an update, delete .yarn.${project}.hash."
+        fi
     fi
 
-    # Bower
-    if ${bowerjson_changed}; then
-        run_as_user "" bower install
+    # Install bower dependencies
+    if [ -f bower.json ]; then
+        bower_json_hash=$(md5sum bower.json | cut -f 1 -d " ")
+        if [ -d bower_components ]; then
+            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${bower_json_hash}
+        fi
+        if [ -z "${bower_dependencies_hash:-}" ] || [ ! -f .bower.${project}.hash ] || [ "${bower_dependencies_hash}" != "$(cat .bower.${project}.hash)" ]; then
+            echo "Installing new bower dependencies"
+            run_as_user "" bower install
+            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${bower_json_hash}
+            echo ${bower_dependencies_hash} > .bower.${project}.hash
+        else
+            echo "Bower dependencies haven't changed. To force an update, delete .bower.${project}.hash."
+        fi
     fi
 
-    # Ruby bundler
-    if ${gemfile_changed} || ${gemfilelock_changed}; then
-        run_as_user "" bundle install --path vendor/bundle
+    # Install ruby dependencies
+    if [ -f Gemfile ]; then
+        gemfile_hash=$(md5sum Gemfile | cut -f 1 -d " ")
+        if [ -d vendor/bundle ]; then
+            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${gemfile_hash}
+        fi
+        if [ -z "${bundler_dependencies_hash:-}" ] || [ ! -f .bundler.${project}.hash ] || [ "${bundler_dependencies_hash}" != "$(cat .bundler.${project}.hash)" ]; then
+            echo "Installing new bundler dependencies"
+            run_as_user "" bundle install --path vendor/bundle
+            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${gemfile_hash}
+            echo ${bundler_dependencies_hash} > .bundler.${project}.hash
+        else
+            echo "Bundler dependencies haven't changed. To force an update, delete .bundler.${project}.hash."
+        fi
     fi
 
-    # Python pip
-    if ${requirements_changed}; then
-        docker_run "" pip3 install --requirement requirements.txt
+    # Install pip dependecies
+    if [ -f requirements.txt ]; then
+        requirements_hash=$(md5sum requirements.txt | cut -f 1 -d " ")
+        pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " "')-${requirements_hash}
+        if [ ! -f .pip.${project}.hash ] || [ "${pip_dependencies_hash}" != "$(cat .pip.${project}.hash)" ]; then
+            echo "Installing new pip dependencies"
+            docker_run "" pip3 install --requirement requirements.txt
+            pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " "')-${requirements_hash}
+            echo ${pip_dependencies_hash} > .pip.${project}.hash
+        else
+            echo "Pip dependencies haven't changed. To force an update, delete .pip.${project}.hash."
+        fi
     fi
 }
 
@@ -351,7 +359,7 @@ case $run_command in
 
         # Setup yarn dependencies
         if [ -f package.json ]; then
-            run_as_user "" yarn run build
+            run_as_user "${module_volumes}" yarn run build
         fi
 
         # Run watch command in the background
@@ -386,7 +394,7 @@ case $run_command in
         fi
 
         # Run the serve container, publishing the port, and detaching if required
-        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${run_options}" ${run_command} $*
+        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${module_volumes} ${run_options}" ${run_command} $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"
@@ -422,13 +430,13 @@ case $run_command in
             trap "kill_container ${project}-watch-site" EXIT
             run_as_user "--detach" jekyll build --watch  # Run site watcher in the background
         fi
-        run_as_user "" yarn run build
-        run_as_user "" yarn run watch
+        run_as_user "${module_volumes}" yarn run build
+        run_as_user "${module_volumes}" yarn run watch
     ;;
     "build")
         update_dependencies
 
-        run_as_user "" yarn run build
+        run_as_user "${module_volumes}" yarn run build
 
         if [ -f _config.yml ]; then
             # For jekyll sites

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Now we literally hash all the dependency files after the dependencies
have been successfully installed, and if that hash changes in the
future, we update the dependencies. This should be much more robust.

In addition, we make sure node_module overrides only happen *after* the
dependency checking and installation step, so they don't mess up
dependency checking.

Fixes #59

QA
--

**Fault tolerance**

Run `./run clean`, then `./run build`. But cancel the command half-way through installing Yarn dependencies.

Now run `./run` - it should install dependencies again, and everything should work fine.

**Module overrides**

Get yourself a checkout of [vanilla-framework](https://github.com/vanilla-framework/vanilla-framework/) which contains an obvious change that will effect the styling of www.ubuntu.com (e.g. `body {font-size: 0.5em !important;}` in `build.scss`).

Now run the site with:

``` bash
./run --node-module $HOME/{path-to-projects-folder}/vanilla-framework
```

You should see that it didn't install dependencies again, but it's using your local version of Vanilla.

Now run simply:

``` bash
./run
```

You should see that it still didn't install dependencies again, but that it's now using the original version of Vanilla.