### PR TITLE
Make md5 work on mac as well as linux

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,3 +19,4 @@ v2.6.1 (2018-02-12): Optional environment variables for exec
 v2.6.2 (2018-02-12): Rename --expose-ports to --expose-port
 v2.6.3 (2018-02-15): Prevent module volumes from creating directories as root
 v2.7.0 (2018-02-15): Improved dependency checking
+v2.7.1 (2018-02-27): Use macOS md5 command on macOS

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -65,6 +65,11 @@ fi
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
 module_volumes=""
 
+# Decide which md5 command to use
+if $(command -v md5sum > /dev/null); then md5_command="md5sum";
+elif $(command -v md5 > /dev/null); then md5_command="md5";
+else echo "No md5 tool available. Exiting."; exit 1; fi
+
 ##
 # Check docker is installed correctly
 ##
@@ -104,7 +109,7 @@ if [[ -f ".docker-project" ]]; then
     project=$(cat .docker-project)
 else
     directory=$(basename `pwd`)
-    hash=$((pwd | md5sum 2> /dev/null || md5 -q -s `pwd`) | cut -c1-8)
+    hash=$(pwd | ${md5_command} | cut -c1-8)
     project=canonical-webteam-${directory}-${hash}
     echo $project > .docker-project
 fi
@@ -268,14 +273,14 @@ update_dependencies() {
 
     # Install yarn dependencies
     if [ -f package.json ]; then
-        package_json_hash=$(md5sum package.json | cut -f 1 -d " ")
+        package_json_hash=$(${md5_command} package.json | cut -c1-8)
         if [ -d node_modules ]; then
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
         fi
         if [ -z "${yarn_dependencies_hash:-}" ] || [ ! -f .yarn.${project}.hash ] || [ "${yarn_dependencies_hash}" != "$(cat .yarn.${project}.hash)" ]; then
             echo "Installing new Yarn dependencies"
             run_as_user "" yarn install --force ${yarn_proxy}
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
             echo ${yarn_dependencies_hash} > .yarn.${project}.hash
         else
             echo "Yarn dependencies haven't changed. To force an update, delete .yarn.${project}.hash."
@@ -284,14 +289,14 @@ update_dependencies() {
 
     # Install bower dependencies
     if [ -f bower.json ]; then
-        bower_json_hash=$(md5sum bower.json | cut -f 1 -d " ")
+        bower_json_hash=$(${md5_command} bower.json | cut -c1-8)
         if [ -d bower_components ]; then
-            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${bower_json_hash}
+            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${bower_json_hash}
         fi
         if [ -z "${bower_dependencies_hash:-}" ] || [ ! -f .bower.${project}.hash ] || [ "${bower_dependencies_hash}" != "$(cat .bower.${project}.hash)" ]; then
             echo "Installing new bower dependencies"
             run_as_user "" bower install
-            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${bower_json_hash}
+            bower_dependencies_hash=$(find bower_components -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${bower_json_hash}
             echo ${bower_dependencies_hash} > .bower.${project}.hash
         else
             echo "Bower dependencies haven't changed. To force an update, delete .bower.${project}.hash."
@@ -300,14 +305,14 @@ update_dependencies() {
 
     # Install ruby dependencies
     if [ -f Gemfile ]; then
-        gemfile_hash=$(md5sum Gemfile | cut -f 1 -d " ")
+        gemfile_hash=$(${md5_command} Gemfile | cut -c1-8)
         if [ -d vendor/bundle ]; then
-            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${gemfile_hash}
+            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${gemfile_hash}
         fi
         if [ -z "${bundler_dependencies_hash:-}" ] || [ ! -f .bundler.${project}.hash ] || [ "${bundler_dependencies_hash}" != "$(cat .bundler.${project}.hash)" ]; then
             echo "Installing new bundler dependencies"
             run_as_user "" bundle install --path vendor/bundle
-            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " ")-${gemfile_hash}
+            bundler_dependencies_hash=$(find vendor/bundle -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${gemfile_hash}
             echo ${bundler_dependencies_hash} > .bundler.${project}.hash
         else
             echo "Bundler dependencies haven't changed. To force an update, delete .bundler.${project}.hash."
@@ -316,12 +321,12 @@ update_dependencies() {
 
     # Install pip dependecies
     if [ -f requirements.txt ]; then
-        requirements_hash=$(md5sum requirements.txt | cut -f 1 -d " ")
-        pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " "')-${requirements_hash}
+        requirements_hash=$(${md5_command} requirements.txt | cut -c1-8)
+        pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${requirements_hash}
         if [ ! -f .pip.${project}.hash ] || [ "${pip_dependencies_hash}" != "$(cat .pip.${project}.hash)" ]; then
             echo "Installing new pip dependencies"
             docker_run "" pip3 install --requirement requirements.txt
-            pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 md5sum | md5sum | cut -f 1 -d " "')-${requirements_hash}
+            pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${requirements_hash}
             echo ${pip_dependencies_hash} > .pip.${project}.hash
         else
             echo "Pip dependencies haven't changed. To force an update, delete .pip.${project}.hash."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
QA
--

On a mac:

``` bash
npm link
cd {some-other-project-that-uses-run-script}
yo canonical-webteam:run  # replace the ./run script - check it installs 2.7.1
./run clean  # Test all run commands
./run build
./run
```