### PR TITLE
Revert "v1.8.0: Use Pipenv instead of requirements.txt"

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.5.2"
+dev_image="canonicalwebteam/dev:v1.4.0"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi
@@ -319,18 +319,14 @@ update_dependencies() {
         fi
     fi
 
-    # Install python dependencies
+    # Install pip dependecies
     if [ -f requirements.txt ]; then
-        echo "Please convert requirements.txt to Pipfile using './run exec pipenv install --three' (or '--two' if your project still lives in the past)."
-        exit
-    elif [ -f Pipfile ]; then
-        pipfile_hash=$(${md5_command} Pipfile | cut -c1-8 || echo '')
-        pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${pipfile_hash}
+        requirements_hash=$(${md5_command} requirements.txt | cut -c1-8)
+        pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${requirements_hash}
         if [ ! -f .pip.${project}.hash ] || [ "${pip_dependencies_hash}" != "$(cat .pip.${project}.hash)" ]; then
             echo "Installing new pip dependencies"
-            docker_run "" pipenv install --system --three
-            pipfile_hash=$(${md5_command} Pipfile | cut -c1-8)
-            pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${pipfile_hash}
+            docker_run "" pip3 install --requirement requirements.txt
+            pip_dependencies_hash=$(docker run --volume ${etc_volume}:/etc ${dev_image} bash -c 'find $(find /usr/local/lib/ -maxdepth 1 -name "python*" -type d | sort | tail -n 1)/dist-packages -type f -print0 | sort -z | xargs -0 '${md5_command}' | '${md5_command}' | cut -c1-8')-${requirements_hash}
             echo ${pip_dependencies_hash} > .pip.${project}.hash
         else
             echo "Pip dependencies haven't changed. To force an update, delete .pip.${project}.hash."

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.8.0",
+  "version": "2.7.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
-  "homepage": "https://github.com/canonical-webteam/generator-canonical-webteam/",
+  "homepage": "https://design.canonical.com/team",
   "author": {
     "name": "Canonical webteam",
     "email": "webteam@canonical.com",


### PR DESCRIPTION
Reverts canonical-webteam/generator-canonical-webteam#62

Actually, the following flow didn't work:

- Create `Pipfile`
- `./run` to install dependencies
- Change `Pipfile`
- `./run` again to update dependencies

This would give this error:

``` bash
$ ./run 
 
Yarn dependencies haven't changed. To force an update, delete .yarn.canonical-webteam-maas.io-2d7fbe0f.hash.
Installing new pip dependencies
Pipfile.lock (d081ae) out of date, updating to (a071ad)…
Locking [dev-packages] dependencies…
/python: not found
```

I tried a remedy to get around this problem - Tried running `pipenv install` as the user inside the docker container, to use `pipenv` to create a virtualenv, as is its intended use, but oddly this didn't install sub-dependencies. E.g. installing `canonicalwebteam.yaml-redirects` didn't install `canonicalwebteam.views-from-yaml`, as it should have.

I am out of ideas, and so I think for now we have to forget my pipedream of using pipenv.

In the future if we move the run script to being LXD/Multipass based, this might mean we could get pipenv to work.