### PR TITLE
Always run yarn run serve

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,4 @@ v2.6.2 (2018-02-12): Rename --expose-ports to --expose-port
 v2.6.3 (2018-02-15): Prevent module volumes from creating directories as root
 v2.7.0 (2018-02-15): Improved dependency checking
 v2.7.1 (2018-02-27): Use macOS md5 command on macOS
+v3.0.0 (2018-03-20): Always use "yarn run serve" for serving site

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -373,22 +373,6 @@ case $run_command in
             run_as_user "--detach" yarn run watch  # Run watch in the background
         fi
 
-        # Select run function and run command
-        run_function="run_as_user"
-        run_command="yarn run serve"
-        run_options=""
-        if [ -f manage.py ]; then  # django
-            run_function="python_run"
-            run_command="python3 manage.py runserver 0.0.0.0:${PORT}"
-        elif [ -f app.py ]; then  # flask
-            run_function="python_run"
-            run_command="flask run --host 0.0.0.0 --port ${PORT}"
-            run_options="--env FLASK_APP=app.py"
-        elif [ -f _config.yml ]; then  # jekyll
-            run_function="run_as_user"
-            run_command="bundle exec jekyll serve -P ${PORT} -H 0.0.0.0"
-        fi
-
         publish_extra_ports=""
         if [ -n "${EXTRA_PORTS:-}" ]; then
             IFS=', ' read -r -a ports_array <<< "$EXTRA_PORTS"
@@ -399,7 +383,7 @@ case $run_command in
         fi
 
         # Run the serve container, publishing the port, and detaching if required
-        ${run_function} "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${module_volumes} ${run_options}" ${run_command} $*
+        run_as_user "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${module_volumes}" yarn run serve $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "2.7.1",
+  "version": "3.0.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Now that evrything is run in the same image, we can simply leave it to the
project to decide what the "serve" command should be, which they can
specify in the package.json

QA
---

Review https://github.com/canonical-websites/snapcraft.io/pull/422, where this version is being used. And also https://github.com/canonical-websites/developer.ubuntu.com/pull/354.