### PR TITLE
Support specifying env vars explicitly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,3 +21,4 @@ v2.6.3 (2018-02-15): Prevent module volumes from creating directories as root
 v2.7.0 (2018-02-15): Improved dependency checking
 v2.7.1 (2018-02-27): Use macOS md5 command on macOS
 v3.0.0 (2018-03-20): Always use "yarn run serve" for serving site
+v3.0.1 (2018-03-21): Support explicitly specifying env vars for any ./run command with --env

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -18,16 +18,16 @@ USAGE="How to use ./run v<%= version %>
 ===
 
   $ ./run \\
-    [-m|--node-module PATH]  # A path to a local node module to use instead of the installed dependencies \\
-    [--no-debug]             # Turn off the DEBUG setting \\
-    [COMMAND]                # Optionally provide a command to run
+    [-e|--env VAR_NAME=value]  # Declare an environment variable to use while running commands \\
+    [-m|--node-module PATH]    # A path to a local node module to use instead of the installed dependencies \\
+    [COMMAND]                  # Optionally provide a command to run
 
 If no COMMAND is provided, \`serve\` will be run.
 
 Commands
 ---
 
-- serve [-p|--port PORT] [-w|--watch] [-d|--detach]: Run a development server (optionally running \`watch\` in the background)
+- serve [-p|--port PORT] [-d|--detach]: Run a development server
 - watch [-s|--watch-site]: Run \`yarn run watch\` (for jekyll sites, watch for changes with \`--watch-site\`)
 - build: Run \`yarn run build\`
 - test: Run \`yarn run test\`
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.4.0"
+dev_image="canonicalwebteam/dev:v1.5.2"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi
@@ -54,7 +54,6 @@ fi
 
 # Defaults environment settings
 PORT=8000
-RUN_DEBUG=true
 
 # Import environment settings
 if [ -f .env ]; then
@@ -64,6 +63,7 @@ fi
 # Other variables
 run_serve_docker_opts="${CANONICAL_WEBTEAM_RUN_SERVE_DOCKER_OPTS:-}"
 module_volumes=""
+env_vars=""
 
 # Decide which md5 command to use
 if $(command -v md5sum > /dev/null); then md5_command="md5sum";
@@ -140,7 +140,11 @@ while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
     key="$1"
 
     case $key in
-        --no-debug) RUN_DEBUG=false ;;
+        -e|--env)
+            if [ -z "${2:-}" ]; then invalid "Missing environment variables. Usage: --env XXXX=yyyy"; fi
+            env_vars="${env_vars} --env ${2}"
+            shift
+        ;;
         -m|--node-module)
             if [ -z "${2:-}" ]; then invalid "Missing module name. Usage: --node-module <path-to-module>."; fi
             # Ensure directories exist, ready to host module volumes
@@ -192,7 +196,8 @@ docker_run () {
         --volume ${usr_local_volume}:/usr/local/       `# Bind local folder to volume`  \
         --volume ${cache_volume}:/home/shared/.cache/  `# Bind cache to volume` \
         --env COMMIT_ID=${commit_id} `# Pass through the commit ID` \
-        ${env_file}                  `# Pass environment variables into the container, if file exists`  \
+        ${env_file}                  `# Pass any files of environment variables to the container`  \
+        ${env_vars}                  `# Pass explicit environment variables to the container`  \
         ${http_proxy}                `# Include HTTP proxy if needed`  \
         ${tty}                       `# Attach a pseudo-terminal, if relevant`  \
         ${docker_run_options}        `# Extra options`  \
@@ -238,16 +243,8 @@ python_run () {
 
     fi
 
-    # Choose debug variable
-    debug="DEBUG=${RUN_DEBUG}"
-    if [ -f manage.py ]; then
-        debug="DJANGO_DEBUG=${RUN_DEBUG}"
-    elif [ -f app.py ]; then
-        debug="FLASK_DEBUG=${RUN_DEBUG}"
-    fi
-
     # Run the command in the python docker image
-    run_as_user "--env ${debug} ${python_run_options}" $@
+    run_as_user "${python_run_options}" $@
 }
 
 create_etc_volume() {
@@ -356,7 +353,6 @@ case $run_command in
                     PORT=${2}
                     shift
                 ;;
-                -w|--watch) run_watcher=true ;;
                 *) invalid "Option '${key}' not recognised." ;;
             esac
             shift
@@ -512,26 +508,28 @@ case $run_command in
     ;;
     "exec")
         expose_ports=""
-        env_vars=""
+        run_as_root=false
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
 
             case $key in
+                -r|--root)
+                    run_as_root=true
+                ;;
                 -p|--expose-port)
                     if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
                     expose_ports="${expose_ports} --publish ${2}:${2}"
-                    shift
-                ;;
-                -e|--env)
-                    if [ -z "${2:-}" ]; then invalid "Missing environment variables. Usage: --env XXXX=yyyy"; fi
-                    env_vars="${env_vars} --env ${2}"
                     shift
                 ;;
                 *) invalid "Option '${key}' not recognised." ;;
             esac
             shift
         done
-        run_as_user "${expose_ports} ${env_vars}" $@
+        if ${run_as_root}; then
+            docker_run "${expose_ports}" $@
+        else
+            run_as_user "${expose_ports}" $@
+        fi
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;
 esac

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Allow passing of environment variables explicitly on any ./run command,
with `./run --env VAR=value`.

This is because `--no-debug` no longer makes sense, since the run script is
now Python framework agnostic (you simply declare the serve command in
package.json). This makes its own "debug" configuration redundant.

So now you can control DEBUG with e.g.: `./run --env FLASK_DEBUG=true`, or
adding `FLASK_DEBUG=true` to the `.env` file.

Also remove the `./run serve --watch` option, which didn't work.

QA
--

Test some of the PRs where this script is used:

- https://github.com/canonical-websites/snapcraft.io/pull/427
- https://github.com/canonical-websites/developer.ubuntu.com/pull/355
- https://github.com/canonical-websites/maas.io/pull/231
- https://github.com/canonical-websites/insights.ubuntu.com/pull/279
- https://github.com/canonical-websites/cn.ubuntu.com/pull/194/
- https://github.com/canonical-websites/www.canonical.com/pull/253