### PR TITLE
run: Be more space-proof

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -108,7 +108,7 @@ fi
 if [[ -f ".docker-project" ]]; then
     project=$(cat .docker-project)
 else
-    directory=$(basename `pwd`)
+    directory="$(basename "$(pwd)")"
     hash=$(pwd | ${md5_command} | cut -c1-8)
     project=canonical-webteam-${directory}-${hash}
     echo $project > .docker-project
@@ -190,8 +190,8 @@ docker_run () {
     docker run  \
         --name ${container_name}     `# Name the container` \
         --rm                         `# Remove the container once it's finished`  \
-        --volume `pwd`:`pwd`         `# Mirror current directory inside container`  \
-        --workdir `pwd`              `# Set current directory to the image's work directory`  \
+        --volume "$(pwd):$(pwd)"     `# Mirror current directory inside container`  \
+        --workdir "$(pwd)"           `# Set current directory to the image's work directory`  \
         --volume ${etc_volume}:/etc  `# Use etc with corresponding user added`  \
         --volume ${usr_local_volume}:/usr/local/       `# Bind local folder to volume`  \
         --volume ${cache_volume}:/home/shared/.cache/  `# Bind cache to volume` \


### PR DESCRIPTION
The run script breaks if the project directory's path contains spaces.  This patch fixes only partially and requires .docker-project to be initialized to avoid crashes, the project parameter string still requires some sanitizing if we really want to determine it from the `pwd`.

This patch is NOT tested, please review.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>