### PR TITLE
v3.1.0: Forward ports; simplify tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,3 +22,4 @@ v2.7.0 (2018-02-15): Improved dependency checking
 v2.7.1 (2018-02-27): Use macOS md5 command on macOS
 v3.0.0 (2018-03-20): Always use "yarn run serve" for serving site
 v3.0.1 (2018-03-21): Support explicitly specifying env vars for any ./run command with --env
+v3.1.0 (2018-05-18): Add port forwarding, simplify tests to always run through package.json

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -434,28 +434,8 @@ case $run_command in
         test_error=false
 
         # Run node tests
-        if [ -f package.json ]; then
-            echo "- Running yarn tests"
-            run_as_user "" yarn run test || test_error=true
-        fi
-
-        # Run django tests
-        if [ -f manage.py ]; then
-            echo "- Running Django tests"
-            python_run "" python3 manage.py test || test_error=true
-        fi
-
-        # Generic python tests
-        if [ -f tests.py ]; then
-            echo "- Running python tests from tests.py"
-            python_run "" python3 tests.py || test_error=true
-        fi
-
-        # Run flake8 (python syntax) checks
-        if [ -f manage.py ] || [ -f app.py ] || [ -f tests.py ]; then
-            echo "- Running flake8 tests"
-            python_run "" flake8 --exclude '*env*,node_modules' || test_error=true
-        fi
+        echo "- Running yarn tests"
+        run_as_user "" yarn run test || test_error=true
 
         # Report success or failure
         if ${test_error}; then

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -27,7 +27,7 @@ If no COMMAND is provided, \`serve\` will be run.
 Commands
 ---
 
-- serve [-p|--port PORT] [-d|--detach]: Run a development server
+- serve [-p|--port PORT] [-d|--detach] [-f|--forward-port]: Run a development server
 - watch [-s|--watch-site]: Run \`yarn run watch\` (for jekyll sites, watch for changes with \`--watch-site\`)
 - build: Run \`yarn run build\`
 - test: Run \`yarn run test\`
@@ -342,6 +342,7 @@ case $run_command in
 
         # Read optional arguments
         detach=""
+        forward_ports=()
         run_watcher=false
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
@@ -352,6 +353,11 @@ case $run_command in
                     if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --port XXXX"; fi
                     PORT=${2}
                     shift
+		;;
+		-f|--forward-port)
+		    if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --port XXXX"; fi
+		    forward_ports+=("${2}")
+		    shift
                 ;;
                 *) invalid "Option '${key}' not recognised." ;;
             esac
@@ -372,14 +378,18 @@ case $run_command in
         publish_extra_ports=""
         if [ -n "${EXTRA_PORTS:-}" ]; then
             IFS=', ' read -r -a ports_array <<< "$EXTRA_PORTS"
-            for extra_port in "${ports_array[@]}"
-            do
+            for extra_port in "${ports_array[@]}"; do
                 publish_extra_ports="${publish_extra_ports} --publish $extra_port:$extra_port"
             done
         fi
 
+        publish_forward_ports=""
+        for forward_port in "${forward_ports[@]}"; do
+            publish_forward_ports="${publish_forward_ports} --publish ${forward_port}:${PORT}"
+        done
+
         # Run the serve container, publishing the port, and detaching if required
-        run_as_user "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${module_volumes}" yarn run serve $*
+        run_as_user "--env PORT=${PORT} --publish ${PORT}:${PORT} ${publish_forward_ports} ${publish_extra_ports} ${detach} ${run_serve_docker_opts} ${module_volumes}" yarn run serve $*
     ;;
     "stop")
         echo "Stopping all running containers for ${project}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
- Add ability to forward extra ports to the main running service (e.g. expose the website on both port 8025 and port 80)
- Simplify tests so they are always run through `yarn run test` - any tests should now be defined in `package.json`

QA
--

Review https://github.com/ubuntudesign/360.canonical.com/pull/110