### PR TITLE
Ignore python *.egg-info folders

### DIFF
--- a/generators/run/templates/gitignore
+++ b/generators/run/templates/gitignore
@@ -41,6 +41,7 @@ package-lock.json
 /parts/
 /prime/
 /stage/
+*.egg-info
 .snapcraft/
 *.snap
 _site/


### PR DESCRIPTION
*.egg-info folders are fodlers created by python for use locally. For example, created if you install the local module with `pip install --editable`.