### PR TITLE
Update image to v1.6.0, which is based on Ubuntu Bionic

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.5.2"
+dev_image="canonicalwebteam/dev:v1.6.0"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi


### PR DESCRIPTION
Update run script to use Bionic image

## QA

Try it out in snapcraft.io (or another project):

- Install this repo globally `npm install -g .`
- cd into snapcraft.io folder
- Run `yo canonical-webteam:run` and update the run script
- `./run` the site as normal. It should run as normal