### PR TITLE
Avoid unset array error

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -342,7 +342,7 @@ case $run_command in
 
         # Read optional arguments
         detach=""
-        forward_ports=()
+        forward_ports=("")
         run_watcher=false
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
@@ -385,7 +385,9 @@ case $run_command in
 
         publish_forward_ports=""
         for forward_port in "${forward_ports[@]}"; do
-            publish_forward_ports="${publish_forward_ports} --publish ${forward_port}:${PORT}"
+            if [ -n "${forward_port}" ]; then
+                publish_forward_ports="${publish_forward_ports} --publish ${forward_port}:${PORT}"
+            fi
         done
 
         # Run the serve container, publishing the port, and detaching if required

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Avoid unset array error in bash by adding an empty value and checking for
empty values.

More information:
https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u

## QA

Try it out in snapcraft.io (or another project):

- Install this repo globally `npm install -g .`
- cd into snapcraft.io folder
- Run `yo canonical-webteam:run` and update the run script
- `./run` the site as normal. It should run as normal

Now make sure a Mac user tests this if you are not one!