### PR TITLE
Update image to v1.6.1 - Allow  mounting .ssh folder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,3 +24,4 @@ v3.0.0 (2018-03-20): Always use "yarn run serve" for serving site
 v3.0.1 (2018-03-21): Support explicitly specifying env vars for any ./run command with --env
 v3.1.0 (2018-05-18): Add port forwarding, simplify tests to always run through package.json
 v3.2.0 (2018-06-18): Update dev image to v1.6.0 which uses Ubuntu Bionic as a base image
+v3.2.1 (2018-06-25): Update dev image to v1.6.1 to be able to mount a .ssh folder

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.0"
+dev_image="canonicalwebteam/dev:v1.6.1"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi


### PR DESCRIPTION
Update the base image. Allowing mounting of a .ssh folder

## QA

This can be QA'd with https://github.com/canonical-websites/snapcraft.io/pull/808

Try it out in snapcraft.io (or another project):

- Install this repo globally `npm install -g .`
- cd into snapcraft.io folder
- Run `yo canonical-webteam:run` and update the run script
- `./run` the site as normal. It should run as normal
