### PR TITLE
Update dev image to v1.6.2 to use node v8.10.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,3 +25,4 @@ v3.0.1 (2018-03-21): Support explicitly specifying env vars for any ./run comman
 v3.1.0 (2018-05-18): Add port forwarding, simplify tests to always run through package.json
 v3.2.0 (2018-06-18): Update dev image to v1.6.0 which uses Ubuntu Bionic as a base image
 v3.2.1 (2018-06-25): Update dev image to v1.6.1 to be able to mount a .ssh folder
+v3.2.2 (2018-10-22): Update dev image to v1.6.2 to use node v8.10.0

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -42,7 +42,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.1"
+dev_image="canonicalwebteam/dev:v1.6.2"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
Update the base image to v1.6.2 to use node v8.10.0

## QA

Try it out in snapcraft.io (or another project):

- Install this repo globally `npm install -g .`
- cd into snapcraft.io folder
- Run `yo canonical-webteam:run` and update the run script
- `./run exec node -v` Should display v8.10.0
- `./run` the site as normal. It should run as normal
