### PR TITLE
Auto-merge minor dependency updates for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "depTypeList": ["devDependencies"],
+      "languages": ["python"],
       "extends": [":automergeMinor"]
     }
   ]


### PR DESCRIPTION
The dependencies in e.g. `generators/django/templates/requirements.txt` are only
a template for new Django projects. As such, I think they should always start from
fairy up-to-date modules. The effort of reviewing PRs for these doesn't seem worth
it.

When we use the template, we can discover any conflicts from new versions, if they
arise, and file bugs to fix them individually.