### PR TITLE
Webpack support; "./run yarn"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,3 +31,4 @@ v3.3.0 (2019-03-26): Add back database support for Django sites
 v3.3.1 (2019-03-27): Include a database for "./run exec" as well
 v3.3.2 (2019-03-27): Better database management
 v3.3.3 (2019-04-04): Update dev image to v1.6.4 to use node v10.x
+v3.4.0 (2019-05-13): Add "./run yarn"; support webpack cache with yarn dependencies calculation

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -32,7 +32,8 @@ Commands
 - build: Run \`yarn run build\`
 - test: Run \`yarn run test\`
 - stop: Stop any running containers
-- exec [-p|--expose-port PORT] <args>: Run a command in the development container (optionally exposing a port to the host)
+- exec [-r|--root] [-p|--expose-port PORT] <args>: Run a command in the development container (optionally exposing a port to the host)
+- yarn [-r|--root] [-p|--expose-port PORT] <script-name>: Run a yarn script from package.json
 - clean: Remove all images and containers, any installed dependencies and the .docker-project file
 - clean-cache: Empty cache files, which are saved between projects (eg, yarn)
 "
@@ -509,6 +510,7 @@ case $run_command in
     "exec")
         expose_ports=""
         run_as_root=false
+
         while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
             key="$1"
 
@@ -526,12 +528,43 @@ case $run_command in
             shift
         done
 
+        update_dependencies
         start_django_db
 
         if ${run_as_root}; then
             docker_run "${expose_ports}" $@
         else
             run_as_user "${expose_ports}" $@
+        fi
+    ;;
+    "yarn")
+        expose_ports=""
+        run_as_root=false
+
+        while [[ -n "${1:-}" ]] && [[ "${1:0:1}" == "-" ]]; do
+            key="$1"
+
+            case $key in
+                -r|--root)
+                    run_as_root=true
+                ;;
+                -p|--expose-port)
+                    if [ -z "${2:-}" ]; then invalid "Missing port number. Usage: --expose-port XXXX"; fi
+                    expose_ports="${expose_ports} --publish ${2}:${2}"
+                    shift
+                ;;
+                *) invalid "Option '${key}' not recognised." ;;
+            esac
+            shift
+        done
+
+        update_dependencies
+        start_django_db
+
+        if ${run_as_root}; then
+            docker_run "${expose_ports}" yarn run $@
+        else
+            run_as_user "${expose_ports}" yarn run $@
         fi
     ;;
     *) invalid "Command '${run_command}' not recognised." ;;

--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -277,13 +277,14 @@ update_dependencies() {
     if [ -f package.json ]; then
         package_json_hash=$(${md5_command} package.json | cut -c1-8)
         if [ -d node_modules ]; then
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f ! -wholename 'node_modules/.cache/*' -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
         fi
         if [ -z "${yarn_dependencies_hash:-}" ] || [ ! -f .yarn.${project}.hash ] || [ "${yarn_dependencies_hash}" != "$(cat .yarn.${project}.hash)" ]; then
-            echo "Installing new Yarn dependencies"
+            echo "Installing new Yarn dependencies (calculated: ${yarn_dependencies_hash}, saved: $(cat .yarn.${project}.hash))"
             run_as_user "" yarn install --force ${yarn_proxy}
-            yarn_dependencies_hash=$(find node_modules -type f -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
+            yarn_dependencies_hash=$(find node_modules -type f ! -wholename 'node_modules/.cache/*' -print0 | sort -z | xargs -0 ${md5_command} | ${md5_command} | cut -c1-8)-${package_json_hash}
             echo ${yarn_dependencies_hash} > .yarn.${project}.hash
+            echo "Saved: ${yarn_dependencies_hash}"
         else
             echo "Yarn dependencies haven't changed. To force an update, delete .yarn.${project}.hash."
         fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
- Exclude webpack npm cache when checking node_modules
- v3.4.0: Add "./run yarn"; support webpack cache with yarn dependencies calculation

QA
--

Copy the run script from `generators/run/templates/run` in this branch into the jaas.ai repo.
Check `./run`, `./run serve`, `./run build` etc. work as expected.
Run `./run build` and then `./run build` again. At least the second time, check you see:

```
Yarn dependencies haven't changed.
```

Now try the new yarn command shortcut:

```
./run yarn build
./run yarn -p 8029 serve
```

Check they work as expected.