### PR TITLE
Update docker image to v1.6.7

### DIFF
--- a/generators/run/templates/run
+++ b/generators/run/templates/run
@@ -45,7 +45,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.5"
+dev_image="canonicalwebteam/dev:v1.6.7"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi


### PR DESCRIPTION
This is docker image was generated to fix a vulnerability with NPM and Yarn that allow arbitrary path access on npm prior to 6.13.3 and yarn prior to 1.21.1.

More info here: https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli

## QA
1. Run `docker run prod-comms.docker-registry.canonical.com/canonicalwebteam/dev:v1.6.7 /bin/bash -c 'npm --version'` and ensure it is version 6.13.4
2. Run `docker run prod-comms.docker-registry.canonical.com/canonicalwebteam/dev:v1.6.7 /bin/bash -c 'yarn --version'` and ensure it is version 1.21.1
