### PR TITLE
v3.4.3 to update docker image version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-canonical-webteam",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Generators for creating and maintaining Canonical webteam projects",
   "homepage": "https://design.canonical.com/team",
   "author": {


### PR DESCRIPTION
This is because v3.4.2 got published with v1.6.4 of the docker image.

This v3.4.3 will be published actually with v1.6.7 of the docker image,
as it should have been.